### PR TITLE
Add admin login and configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ADMIN_USER=admin
+ADMIN_PASS=admin
+SECRET_KEY=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+config/config.json
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py .
+COPY templates ./templates
+COPY config ./config
 
 EXPOSE 8000
 CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:8000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -1,14 +1,49 @@
-import os, csv, io, requests
+import os, csv, io, json, requests
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP, InvalidOperation
-from flask import Flask, jsonify, request, abort
+from flask import (
+    Flask,
+    jsonify,
+    request,
+    abort,
+    render_template,
+    redirect,
+    url_for,
+    session,
+)
+from dotenv import load_dotenv
 
 CSV_URL = os.getenv(
     "CSV_URL",
     "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv",
 )
 
+load_dotenv()
+
 app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "changeme")
+
+ADMIN_USER = os.getenv("ADMIN_USER", "admin")
+ADMIN_PASS = os.getenv("ADMIN_PASS", "admin")
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config", "config.json")
+
+
+def _load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {
+        "alquiler_base": "",
+        "fecha_inicio_contrato": "",
+        "periodo_actualizacion_meses": "",
+    }
+
+
+def _save_config(data):
+    os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+    with open(CONFIG_FILE, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
 
 def _leer_csv():
     r = requests.get(CSV_URL, timeout=20)
@@ -93,6 +128,42 @@ def ipc_ultimos():
         "count": len(out),
         "data": out
     })
+
+
+@app.get("/")
+def index():
+    return ipc_ultimos()
+
+
+@app.route("/adm", methods=["GET", "POST"])
+def admin():
+    if session.get("logged_in"):
+        config = _load_config()
+        if request.method == "POST":
+            config.update(
+                {
+                    "alquiler_base": request.form.get("alquiler_base", ""),
+                    "fecha_inicio_contrato": request.form.get(
+                        "fecha_inicio_contrato", ""
+                    ),
+                    "periodo_actualizacion_meses": request.form.get(
+                        "periodo_actualizacion_meses", ""
+                    ),
+                }
+            )
+            _save_config(config)
+        return render_template("config.html", config=config)
+
+    error = None
+    if request.method == "POST":
+        if (
+            request.form.get("username") == ADMIN_USER
+            and request.form.get("password") == ADMIN_PASS
+        ):
+            session["logged_in"] = True
+            return redirect(url_for("admin"))
+        error = "Credenciales inválidas"
+    return render_template("login.html", error=error)
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,18 @@ services:
   ipc-api:
     build: .
     container_name: ipc-api
+    env_file: .env
     environment:
       # Podés overridear la URL si fuese necesario
       CSV_URL: "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv"
     ports:
       - "6060:8000"
+    volumes:
+      - ./config:/app/config
     restart: unless-stopped
+    networks:
+      - nginx_net
+
+networks:
+  nginx_net:
+    external: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.3
 requests>=2.31.0
 gunicorn>=21.2.0
+python-dotenv>=1.0.0

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="es">
+<head><meta charset="utf-8"><title>Configuración</title></head>
+<body>
+  <h1>Configuración</h1>
+  <form method="post">
+    <div>
+      <label>Alquiler base:</label>
+      <input type="number" step="0.01" name="alquiler_base" value="{{ config.alquiler_base }}">
+    </div>
+    <div>
+      <label>Fecha de inicio de contrato:</label>
+      <input type="date" name="fecha_inicio_contrato" value="{{ config.fecha_inicio_contrato }}">
+    </div>
+    <div>
+      <label>Período de actualización por IPC (meses):</label>
+      <input type="number" name="periodo_actualizacion_meses" value="{{ config.periodo_actualizacion_meses }}">
+    </div>
+    <button type="submit">Guardar</button>
+  </form>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+<head><meta charset="utf-8"><title>Login</title></head>
+<body>
+  <h1>Admin Login</h1>
+  {% if error %}<p style="color:red;">{{ error }}</p>{% endif %}
+  <form method="post">
+    <input type="text" name="username" placeholder="Usuario" required>
+    <input type="password" name="password" placeholder="Contraseña" required>
+    <button type="submit">Ingresar</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add admin login page at /adm and persist settings to config file
- serve IPC JSON at root route
- load credentials from .env and allow configuration via simple UI
- attach container to nginx_net network for nginx integration

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897abd237e88332a1f5f4d0e2f61fc3