### PR TITLE
Add IPC-based rent schedule table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ADMIN_USER=admin
+ADMIN_PASS=admin
+SECRET_KEY=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+config/config.json
+__pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app.py .
+COPY templates ./templates
+COPY config ./config
 
 EXPOSE 8000
 CMD ["gunicorn", "-w", "2", "-b", "0.0.0.0:8000", "app:app"]

--- a/app.py
+++ b/app.py
@@ -1,14 +1,49 @@
-import os, csv, io, requests
+import os, csv, io, json, requests
 from datetime import datetime
 from decimal import Decimal, ROUND_HALF_UP, InvalidOperation
-from flask import Flask, jsonify, request, abort
+from flask import (
+    Flask,
+    jsonify,
+    request,
+    abort,
+    render_template,
+    redirect,
+    url_for,
+    session,
+)
+from dotenv import load_dotenv
 
 CSV_URL = os.getenv(
     "CSV_URL",
     "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv",
 )
 
+load_dotenv()
+
 app = Flask(__name__)
+app.secret_key = os.getenv("SECRET_KEY", "changeme")
+
+ADMIN_USER = os.getenv("ADMIN_USER", "admin")
+ADMIN_PASS = os.getenv("ADMIN_PASS", "admin")
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config", "config.json")
+
+
+def _load_config():
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {
+        "alquiler_base": "",
+        "fecha_inicio_contrato": "",
+        "periodo_actualizacion_meses": "",
+    }
+
+
+def _save_config(data):
+    os.makedirs(os.path.dirname(CONFIG_FILE), exist_ok=True)
+    with open(CONFIG_FILE, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
 
 def _leer_csv():
     r = requests.get(CSV_URL, timeout=20)
@@ -25,6 +60,100 @@ def _parse_fechas(f):
         return datetime.strptime(f, "%Y-%m-%d").strftime("%Y-%m")
     except Exception:
         return f[:7]
+
+
+def _ipc_dict():
+    """Devuelve dict {"YYYY-MM": Decimal(proporción)}"""
+    _, filas = _leer_csv()
+    out = {}
+    prev_indice_dec = None
+    for row in filas:
+        if len(row) < 2:
+            continue
+        mes = _parse_fechas(row[0])
+        try:
+            indice_dec = Decimal(row[1])
+        except (ValueError, InvalidOperation):
+            continue
+        ipc_prop_dec = None
+        if len(row) >= 9 and row[8] not in ("", None, ""):
+            try:
+                ipc_prop_dec = Decimal(row[8])
+            except (ValueError, InvalidOperation):
+                ipc_prop_dec = None
+        if ipc_prop_dec is None and prev_indice_dec is not None and prev_indice_dec > 0:
+            ipc_prop_dec = (indice_dec / prev_indice_dec) - Decimal("1")
+        if ipc_prop_dec is not None:
+            out[mes] = ipc_prop_dec
+        prev_indice_dec = indice_dec
+    return out
+
+
+def _add_months(ym: str, m: int) -> str:
+    """Suma m meses a 'YYYY-MM'"""
+    dt = datetime.strptime(ym, "%Y-%m")
+    y = dt.year + ((dt.month - 1 + m) // 12)
+    month = (dt.month - 1 + m) % 12 + 1
+    return f"{y:04d}-{month:02d}"
+
+
+def generar_tabla_alquiler(alquiler_base: Decimal, mes_inicio: str, periodo: int, meses: int = 12):
+    ipc = _ipc_dict()
+    meses_es = [
+        "Enero",
+        "Febrero",
+        "Marzo",
+        "Abril",
+        "Mayo",
+        "Junio",
+        "Julio",
+        "Agosto",
+        "Septiembre",
+        "Octubre",
+        "Noviembre",
+        "Diciembre",
+    ]
+    tabla = []
+    valores = {0: Decimal(alquiler_base).quantize(Decimal("1"), rounding=ROUND_HALF_UP)}
+    for i in range(meses):
+        ym = _add_months(mes_inicio, i)
+        k = i // periodo
+        if k not in valores:
+            Uk = _add_months(mes_inicio, k * periodo)
+            m1 = _add_months(Uk, -3)
+            m2 = _add_months(Uk, -2)
+            m3 = _add_months(Uk, -1)
+            if all(m in ipc for m in (m1, m2, m3)):
+                F = (Decimal("1") + ipc[m1]) * (Decimal("1") + ipc[m2]) * (Decimal("1") + ipc[m3])
+                valores[k] = (valores[k - 1] * F).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+            else:
+                valores[k] = valores[k - 1]
+        valor = valores[k]
+        provisorio = False
+        Uk = _add_months(mes_inicio, k * periodo)
+        m1 = _add_months(Uk, -3)
+        m2 = _add_months(Uk, -2)
+        m3 = _add_months(Uk, -1)
+        if k > 0 and any(m not in ipc for m in (m1, m2, m3)):
+            provisorio = True
+
+        ipc_pct = None
+        if ym in ipc:
+            ipc_pct = (ipc[ym] * Decimal("100")).quantize(
+                Decimal("0.1"), rounding=ROUND_HALF_UP
+            )
+
+        dt = datetime.strptime(ym, "%Y-%m")
+        nombre_mes = f"{meses_es[dt.month - 1]} {dt.year}"
+        tabla.append(
+            {
+                "mes": nombre_mes,
+                "valor": float(valor),
+                "provisorio": provisorio,
+                "ipc": float(ipc_pct) if ipc_pct is not None else None,
+            }
+        )
+    return tabla
 
 @app.get("/health")
 def health():
@@ -93,6 +222,98 @@ def ipc_ultimos():
         "count": len(out),
         "data": out
     })
+
+
+@app.get("/")
+def index():
+    config = _load_config()
+    tabla = []
+    try:
+        base = Decimal(config.get("alquiler_base"))
+        inicio = config.get("fecha_inicio_contrato", "")[:7]
+        periodo = int(config.get("periodo_actualizacion_meses") or 3)
+        tabla = generar_tabla_alquiler(base, inicio, periodo)
+    except Exception:
+        tabla = []
+    return render_template("index.html", tabla=tabla)
+
+
+@app.get("/alquiler/tabla")
+def alquiler_tabla():
+    config = _load_config()
+    base = request.args.get("alquiler_base", config.get("alquiler_base"))
+    inicio = request.args.get(
+        "fecha_inicio_contrato", config.get("fecha_inicio_contrato", "")[:7]
+    )
+    periodo = int(
+        request.args.get(
+            "periodo_actualizacion_meses",
+            config.get("periodo_actualizacion_meses") or 3,
+        )
+    )
+    meses = int(request.args.get("meses", "12"))
+    if not base or not inicio:
+        abort(400, "Faltan parámetros")
+    try:
+        base_dec = Decimal(base)
+    except InvalidOperation:
+        abort(400, "alquiler_base inválido")
+    tabla = generar_tabla_alquiler(base_dec, inicio[:7], periodo, meses)
+    return jsonify({"tabla": tabla})
+
+@app.route("/adm", methods=["GET", "POST"])
+def admin():
+    """Pantalla de login y configuración"""
+    if session.get("logged_in"):
+        config = _load_config()
+        if request.method == "POST":
+            config.update(
+                {
+                    "alquiler_base": request.form.get("alquiler_base", ""),
+                    "fecha_inicio_contrato": request.form.get(
+                        "fecha_inicio_contrato", ""
+                    ),
+                    "periodo_actualizacion_meses": request.form.get(
+                        "periodo_actualizacion_meses", ""
+                    ),
+                }
+            )
+            try:
+                _save_config(config)
+                if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+                    return jsonify({"ok": True})
+            except Exception:
+                if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+                    return jsonify({"ok": False}), 500
+                raise
+        tabla = []
+        try:
+            base = Decimal(config.get("alquiler_base"))
+            inicio = config.get("fecha_inicio_contrato", "")[:7]
+            periodo = int(config.get("periodo_actualizacion_meses") or 3)
+            tabla = generar_tabla_alquiler(base, inicio, periodo)
+        except Exception:
+            tabla = []
+        return render_template("config.html", config=config, tabla=tabla)
+
+    error = None
+    if request.method == "POST":
+        if (
+            request.form.get("username") == ADMIN_USER
+            and request.form.get("password") == ADMIN_PASS
+        ):
+            session.clear()
+            session["logged_in"] = True
+            session.permanent = False  # expira al cerrar el navegador
+            return redirect(url_for("admin"))
+        error = "Credenciales inválidas"
+    return render_template("login.html", error=error)
+
+
+@app.post("/logout")
+def logout():
+    session.clear()
+    return redirect(url_for("admin"))
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=8000)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,18 @@ services:
   ipc-api:
     build: .
     container_name: ipc-api
+    env_file: .env
     environment:
       # Podés overridear la URL si fuese necesario
       CSV_URL: "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv"
     ports:
       - "6060:8000"
+    volumes:
+      - ./config:/app/config
     restart: unless-stopped
+    networks:
+      - nginx_net
+
+networks:
+  nginx_net:
+    external: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask==3.0.3
 requests>=2.31.0
 gunicorn>=21.2.0
+python-dotenv>=1.0.0

--- a/templates/config.html
+++ b/templates/config.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Configuración</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    #overlay {position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:1000;}
+  </style>
+</head>
+<body>
+  <nav class="navbar navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">Configuración</span>
+      <form class="d-flex" action="{{ url_for('logout') }}" method="post">
+        <button class="btn btn-outline-secondary" type="submit">Salir</button>
+      </form>
+    </div>
+  </nav>
+  <div class="container">
+    <div id="alert-placeholder"></div>
+    <form id="config-form" method="post">
+      <div class="mb-3">
+        <label class="form-label">Alquiler base</label>
+        <input type="number" step="0.01" class="form-control" name="alquiler_base" value="{{ config.alquiler_base }}">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Fecha de inicio de contrato</label>
+        <input type="date" class="form-control" name="fecha_inicio_contrato" value="{{ config.fecha_inicio_contrato }}">
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Período de actualización por IPC (meses)</label>
+        <input type="number" class="form-control" name="periodo_actualizacion_meses" value="{{ config.periodo_actualizacion_meses }}">
+      </div>
+      <button type="submit" class="btn btn-primary">Guardar</button>
+    </form>
+    {% if tabla %}
+    <hr>
+    <h2 class="h5 mt-4">Tabla de alquiler</h2>
+    <table class="table table-striped">
+      <thead>
+        <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
+      </thead>
+      <tbody>
+      {% for fila in tabla %}
+        <tr>
+          <td>{{ fila.mes }}</td>
+          <td>{% if fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+          <td>${{ '{:,.0f}'.format(fila.valor) }}</td>
+          <td>{% if fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+  </div>
+  <div id="overlay"><div class="spinner-border text-primary" role="status"></div></div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const form = document.getElementById('config-form');
+    const overlay = document.getElementById('overlay');
+    const alertPlaceholder = document.getElementById('alert-placeholder');
+    function showAlert(message, type) {
+      const wrapper = document.createElement('div');
+      wrapper.innerHTML = `<div class="alert alert-${type} alert-dismissible" role="alert">${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
+      alertPlaceholder.append(wrapper);
+    }
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      overlay.style.display = 'flex';
+      fetch('{{ url_for("admin") }}', {
+        method: 'POST',
+        body: new FormData(form),
+        headers: {'X-Requested-With': 'XMLHttpRequest'}
+      }).then(r => {
+        if (!r.ok) throw new Error();
+        return r.json();
+      }).then(data => {
+        overlay.style.display = 'none';
+        showAlert('Configuración guardada correctamente', 'success');
+        setTimeout(() => window.location.reload(), 500);
+      }).catch(() => {
+        overlay.style.display = 'none';
+        showAlert('Error al guardar configuración', 'danger');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tabla de alquiler</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+  <div class="container py-4">
+    <h1 class="h4 mb-4">Tabla de alquiler</h1>
+    {% if tabla %}
+    <table class="table table-striped">
+      <thead>
+        <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
+      </thead>
+      <tbody>
+        {% for fila in tabla %}
+        <tr>
+          <td>{{ fila.mes }}</td>
+          <td>{% if fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+          <td>${{ '{:,.0f}'.format(fila.valor) }}</td>
+          <td>{% if fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% else %}
+    <div class="alert alert-info">No hay datos de configuración. Ingresá a <a href="{{ url_for('admin') }}">/adm</a> para cargarlos.</div>
+    {% endif %}
+  </div>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center vh-100">
+  <div class="card p-4" style="min-width:300px;">
+    <h1 class="h4 mb-3 text-center">Admin Login</h1>
+    {% if error %}
+      <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <input type="text" class="form-control" name="username" placeholder="Usuario" required>
+      </div>
+      <div class="mb-3">
+        <input type="password" class="form-control" name="password" placeholder="Contraseña" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- compute rental schedule from IPC data and update periods
- expose `/alquiler/tabla` endpoint returning the calculated table
- show rent table on admin page with automatic refresh after saving settings
- render the rent table at the root path and serve IPC JSON from `/ipc/ultimos`
- display monthly IPC percentages alongside each rent value

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897abd237e88332a1f5f4d0e2f61fc3