### PR TITLE
feat: soporte para ajustes de alquiler variables

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,9 +19,9 @@
         <tr>
           <td>{{ fila.mes }}</td>
 
-          <td>{% if fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+          <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
           <td>${{ '{:,.0f}'.format(fila.valor) }}</td>
-          <td>{% if fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- Calcula ajustes de alquiler para períodos de cualquier duración
- Incluye filas de ajuste y banderas provisorias en la tabla generada
- Permite renderizar la tabla cuando las filas de ajuste no poseen IPC ni bandera de provisorio

## Testing
- `pytest -q`
- `python - <<'PY'
from decimal import Decimal
import app
from flask import render_template

ipc_data = {f"2023-{m:02d}": Decimal('0.01') for m in range(1,13)}
ipc_data.update({f"2022-{m:02d}": Decimal('0.01') for m in (10,11,12)})
def stub_ipc_dict(): return ipc_data
app._ipc_dict = stub_ipc_dict

base = Decimal('1000')
start = '2023-01'

tabla = app.generar_tabla_alquiler(base, start, 3, 12)

with app.app.app_context():
    html = render_template('index.html', tabla=tabla)
    print(html[:200])
    print('... length', len(html))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6897e782dcdc8332bd48c509e0b29dbc