### PR TITLE
feat: soporte para ajustes de alquiler variables

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -44,7 +44,8 @@
     {% if tabla %}
     <hr>
     <h2 class="h5 mt-4">Tabla de alquiler</h2>
-    <table class="table table-striped">
+    <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
+    <table class="table table-striped table-bordered">
       <thead>
 
         <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
@@ -52,12 +53,12 @@
       </thead>
       <tbody>
       {% for fila in tabla %}
-        <tr>
+        <tr class="{% if fila.future %}opacity-50{% endif %}{% if fila.tipo == 'ajuste' %} fst-italic{% endif %}">
           <td>{{ fila.mes }}</td>
-          <td>{% if fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+          <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
 
-          <td>${{ '{:,.0f}'.format(fila.valor) }}</td>
-          <td>{% if fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}</td>
+          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,18 +10,19 @@
   <div class="container py-4">
     <h1 class="h4 mb-4">Tabla de alquiler</h1>
     {% if tabla %}
-    <table class="table table-striped">
+    <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
+    <table class="table table-striped table-bordered">
       <thead>
         <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
       </thead>
       <tbody>
         {% for fila in tabla %}
-        <tr>
+        <tr class="{% if fila.future %}opacity-50{% endif %}{% if fila.tipo == 'ajuste' %} fst-italic{% endif %}">
           <td>{{ fila.mes }}</td>
 
-          <td>{% if fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>${{ '{:,.0f}'.format(fila.valor) }}</td>
-          <td>{% if fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}</td>
+          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- Calcula ajustes de alquiler para períodos de cualquier duración
- Incluye fecha actual sobre las tablas y oculta valores de meses futuros
- Resalta visualmente los meses venideros y pone en cursiva las filas de ajuste

## Testing
- `pytest -q`
- `python - <<'PY'
from decimal import Decimal
from types import SimpleNamespace
from datetime import date
import app
from flask import render_template

ipc_data = {f"2023-{m:02d}": Decimal('0.01') for m in range(1,13)}
ipc_data.update({f"2022-{m:02d}": Decimal('0.01') for m in (10,11,12)})
def stub_ipc_dict(): return ipc_data
app._ipc_dict = stub_ipc_dict

class StubDate:
    @staticmethod
    def today():
        return date(2023,6,15)
app.date = StubDate

base = Decimal('1000')
start = '2023-01'
tabla = app.generar_tabla_alquiler(base, start, 3, 12)
print(tabla[:5])
print('... last rows', tabla[-3:])

with app.app.app_context():
    html = render_template('index.html', tabla=tabla, fecha_hoy='15-06-2023')
    print(html.split('\n')[0:15])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6897e782dcdc8332bd48c509e0b29dbc