### PR TITLE
Agregar login simple y gestión de usuarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 config/config.json
+config/users.json
 __pycache__/

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,0 +1,48 @@
+import os
+import json
+
+USERS_FILE = os.path.join(os.path.dirname(__file__), "..", "config", "users.json")
+
+
+def load_users():
+    """Load list of allowed users from JSON file."""
+    path = os.path.abspath(USERS_FILE)
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+                if isinstance(data, list):
+                    return [str(u).lower() for u in data]
+        except (json.JSONDecodeError, OSError):
+            return []
+    return []
+
+
+def save_users(users):
+    """Persist user list to JSON file."""
+    path = os.path.abspath(USERS_FILE)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(sorted({u.lower() for u in users}), fh)
+
+
+def add_user(name):
+    """Add a user to the list (case insensitive)."""
+    if not name:
+        return
+    users = load_users()
+    name_l = name.lower()
+    if name_l not in users:
+        users.append(name_l)
+        save_users(users)
+
+
+def delete_user(name):
+    """Remove a user from the list (case insensitive)."""
+    if not name:
+        return
+    users = load_users()
+    name_l = name.lower()
+    if name_l in users:
+        users.remove(name_l)
+        save_users(users)

--- a/templates/config.html
+++ b/templates/config.html
@@ -20,6 +20,19 @@
   </nav>
   <div class="container">
     <div id="alert-placeholder"></div>
+    <h2 class="h5">Usuarios</h2>
+    <form class="mb-3 d-flex" action="{{ url_for('app.admin_add_user') }}" method="post">
+      <input type="text" class="form-control me-2" name="new_user" placeholder="Nombre">
+      <button class="btn btn-primary" type="submit">Agregar usuario</button>
+    </form>
+    <form class="mb-4 d-flex" action="{{ url_for('app.admin_delete_user') }}" method="post">
+      <select class="form-select me-2" name="user">
+        {% for u in users %}
+        <option value="{{ u }}">{{ u }}</option>
+        {% endfor %}
+      </select>
+      <button class="btn btn-danger" type="submit">Eliminar usuario</button>
+    </form>
     <form id="config-form" method="post">
       <div class="mb-3">
         <label class="form-label">Alquiler base</label>

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ingreso</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center vh-100">
+  <div class="card p-4" style="min-width:300px;">
+    <h1 class="h5 mb-3 text-center">Ingresá sólo tu nombre</h1>
+    {% if error %}
+      <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <input type="text" class="form-control" name="name" placeholder="Nombre" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Permitir ingreso en `/` solicitando sólo el nombre y verificando contra una lista de usuarios
- Añadir servicio y panel de administración para agregar o eliminar usuarios, persistidos en JSON
- Ignorar archivo `config/users.json`

## Testing
- `python -m py_compile app.py routes.py services/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68980cc819788332a7f33a88f2f5f1dc