### PR TITLE
Agregar login simple y gestión de usuarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 config/config.json
+config/users.json
 __pycache__/

--- a/routes.py
+++ b/routes.py
@@ -20,6 +20,7 @@ from services.config_service import (
 )
 from services.ipc_service import leer_csv, parse_fechas
 from services.alquiler_service import generar_tabla_alquiler
+from services.user_service import load_users, add_user, delete_user
 
 bp = Blueprint("app", __name__)
 
@@ -77,8 +78,20 @@ def ipc_ultimos():
     return jsonify({"source": CSV_URL, "last_month": last_date, "count": len(out), "data": out})
 
 
-@bp.get("/")
+@bp.route("/", methods=["GET", "POST"])
 def index():
+    if not session.get("user"):
+        error = None
+        if request.method == "POST":
+            nombre = request.form.get("name", "").strip().lower()
+            if nombre and nombre in load_users():
+                session.clear()
+                session["user"] = nombre
+                session.permanent = False  # expira al cerrar el navegador
+                return redirect(url_for("app.index"))
+            error = "Usuario no encontrado"
+        return render_template("user_login.html", error=error)
+
     config = load_config()
     tabla = []
     try:
@@ -118,6 +131,7 @@ def admin():
     """Pantalla de login y configuración"""
     if session.get("logged_in"):
         config = load_config()
+        users = load_users()
         if request.method == "POST":
             config.update(
                 {
@@ -147,6 +161,7 @@ def admin():
             config=config,
             tabla=tabla,
             fecha_hoy=date.today().strftime("%d-%m-%Y"),
+            users=users,
         )
 
     error = None
@@ -163,7 +178,30 @@ def admin():
     return render_template("login.html", error=error)
 
 
+@bp.post("/adm/users/add")
+def admin_add_user():
+    if not session.get("logged_in"):
+        abort(403)
+    nombre = request.form.get("new_user", "").strip().lower()
+    if nombre:
+        add_user(nombre)
+    return redirect(url_for("app.admin"))
+
+
+@bp.post("/adm/users/delete")
+def admin_delete_user():
+    if not session.get("logged_in"):
+        abort(403)
+    nombre = request.form.get("user", "").strip().lower()
+    if nombre:
+        delete_user(nombre)
+    return redirect(url_for("app.admin"))
+
+
 @bp.post("/logout")
 def logout():
+    is_admin = session.get("logged_in")
     session.clear()
-    return redirect(url_for("app.admin"))
+    if is_admin:
+        return redirect(url_for("app.admin"))
+    return redirect(url_for("app.index"))

--- a/services/user_service.py
+++ b/services/user_service.py
@@ -1,0 +1,48 @@
+import os
+import json
+
+USERS_FILE = os.path.join(os.path.dirname(__file__), "..", "config", "users.json")
+
+
+def load_users():
+    """Load list of allowed users from JSON file."""
+    path = os.path.abspath(USERS_FILE)
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                data = json.load(fh)
+                if isinstance(data, list):
+                    return [str(u).lower() for u in data]
+        except (json.JSONDecodeError, OSError):
+            return []
+    return []
+
+
+def save_users(users):
+    """Persist user list to JSON file."""
+    path = os.path.abspath(USERS_FILE)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(sorted({u.lower() for u in users}), fh)
+
+
+def add_user(name):
+    """Add a user to the list (case insensitive)."""
+    if not name:
+        return
+    users = load_users()
+    name_l = name.lower()
+    if name_l not in users:
+        users.append(name_l)
+        save_users(users)
+
+
+def delete_user(name):
+    """Remove a user from the list (case insensitive)."""
+    if not name:
+        return
+    users = load_users()
+    name_l = name.lower()
+    if name_l in users:
+        users.remove(name_l)
+        save_users(users)

--- a/templates/config.html
+++ b/templates/config.html
@@ -20,6 +20,19 @@
   </nav>
   <div class="container">
     <div id="alert-placeholder"></div>
+    <h2 class="h5">Usuarios</h2>
+    <form class="mb-3 d-flex" action="{{ url_for('app.admin_add_user') }}" method="post">
+      <input type="text" class="form-control me-2" name="new_user" placeholder="Nombre">
+      <button class="btn btn-primary" type="submit">Agregar usuario</button>
+    </form>
+    <form class="mb-4 d-flex" action="{{ url_for('app.admin_delete_user') }}" method="post">
+      <select class="form-select me-2" name="user">
+        {% for u in users %}
+        <option value="{{ u }}">{{ u }}</option>
+        {% endfor %}
+      </select>
+      <button class="btn btn-danger" type="submit">Eliminar usuario</button>
+    </form>
     <form id="config-form" method="post">
       <div class="mb-3">
         <label class="form-label">Alquiler base</label>
@@ -93,6 +106,9 @@
         overlay.style.display = 'none';
         showAlert('Error al guardar configuración', 'danger');
       });
+    });
+    window.addEventListener('beforeunload', () => {
+      navigator.sendBeacon('{{ url_for('app.logout') }}', '');
     });
   </script>
 </body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,15 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
 <body>
-  <div class="container py-4">
+  <nav class="navbar navbar-light bg-light mb-4">
+    <div class="container-fluid">
+      <span class="navbar-brand mb-0 h1">Tabla de alquiler</span>
+      <form class="d-flex" action="{{ url_for('app.logout') }}" method="post">
+        <button class="btn btn-outline-secondary" type="submit">Salir</button>
+      </form>
+    </div>
+  </nav>
+  <div class="container">
     <h1 class="h4 mb-4">Tabla de alquiler</h1>
     {% if tabla %}
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
@@ -31,5 +39,11 @@
     <div class="alert alert-info">No hay datos de configuración. Ingresá a <a href="{{ url_for('app.admin') }}">/adm</a> para cargarlos.</div>
     {% endif %}
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    window.addEventListener('beforeunload', () => {
+      navigator.sendBeacon('{{ url_for('app.logout') }}', '');
+    });
+  </script>
 </body>
 </html>

--- a/templates/user_login.html
+++ b/templates/user_login.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ingreso</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="d-flex align-items-center justify-content-center vh-100">
+  <div class="card p-4" style="min-width:300px;">
+    <h1 class="h5 mb-3 text-center">Ingresá sólo tu nombre</h1>
+    {% if error %}
+      <div class="alert alert-danger" role="alert">{{ error }}</div>
+    {% endif %}
+    <form method="post">
+      <div class="mb-3">
+        <input type="text" class="form-control" name="name" placeholder="Nombre" required>
+      </div>
+      <button type="submit" class="btn btn-primary w-100">Ingresar</button>
+    </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Agregar botón de salida y cierre automático de sesión al consultar la tabla
- Cerrar sesión al cerrar la ventana tanto en la pantalla principal como en el panel de configuración
- Ajustar el logout para redirigir según el tipo de usuario

## Testing
- `python -m py_compile app.py routes.py services/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68980cc819788332a7f33a88f2f5f1dc