### PR TITLE
Improve rental table periods and colors

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -7,6 +7,11 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     #overlay {position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:1000;}
+    .periodo0.offset0 {background-color:#ffffff;}
+    .periodo0.offset1 {background-color:#f2f2f2;}
+    .periodo1.offset0 {background-color:#e7f5ff;}
+    .periodo1.offset1 {background-color:#d0ebff;}
+    .ajuste {background-color:#e6ffe6;}
   </style>
 </head>
 <body>
@@ -58,19 +63,16 @@
     <hr>
     <h2 class="h5 mt-4">Tabla de alquiler</h2>
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
-    <table class="table table-striped table-bordered">
+    <table class="table table-bordered">
       <thead>
-
-        <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
-
+        <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
       </thead>
       <tbody>
       {% for fila in tabla %}
-        <tr class="{% if fila.future %}opacity-50{% endif %}{% if fila.tipo == 'ajuste' %} fst-italic{% endif %}">
+        <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}{% if fila.future %} opacity-50{% endif %}">
           <td>{{ fila.mes }}</td>
           <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}</td>
-          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tabla de alquiler</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    .periodo0.offset0 {background-color:#ffffff;}
+    .periodo0.offset1 {background-color:#f2f2f2;}
+    .periodo1.offset0 {background-color:#e7f5ff;}
+    .periodo1.offset1 {background-color:#d0ebff;}
+    .ajuste {background-color:#e6ffe6;}
+  </style>
 </head>
 <body>
   <nav class="navbar navbar-light bg-light mb-4">
@@ -19,18 +26,16 @@
     <h1 class="h4 mb-4">Tabla de alquiler</h1>
     {% if tabla %}
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
-    <table class="table table-striped table-bordered">
+    <table class="table table-bordered">
       <thead>
-        <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
+        <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
       </thead>
       <tbody>
         {% for fila in tabla %}
-        <tr class="{% if fila.future %}opacity-50{% endif %}{% if fila.tipo == 'ajuste' %} fst-italic{% endif %}">
+        <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}{% if fila.future %} opacity-50{% endif %}">
           <td>{{ fila.mes }}</td>
-
           <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}</td>
-          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- limit rent table generation to current month plus next
- include period data to alternate row colors
- remove empty column and apply color styling for periods and adjustments

## Testing
- `python -m py_compile services/alquiler_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e53644e88332aab9888863408b43