### PR TITLE
Improve rental table periods and colors

### DIFF
--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -30,6 +30,7 @@ def add_months(ym: str, m: int) -> str:
 def generar_tabla_alquiler(alquiler_base: Decimal, mes_inicio: str, periodo: int, meses: int = 12):
     ipc = ipc_dict()
     hoy_ym = date.today().strftime("%Y-%m")
+    max_ym = add_months(hoy_ym, 1)
     tabla = []
     valor_actual = Decimal(alquiler_base).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
     valor_periodo = valor_actual
@@ -38,56 +39,65 @@ def generar_tabla_alquiler(alquiler_base: Decimal, mes_inicio: str, periodo: int
     for i in range(meses):
         ym = add_months(mes_inicio, i)
         offset = i % periodo
+        period_idx = i // periodo
+        mostrar_valor = ym <= max_ym
+        future = ym > max_ym
+
         ajuste_valor = None
-        if offset == 0:
-            k = i // periodo
-            Uk = add_months(mes_inicio, k * periodo)
-            if k > 0:
-                meses_previos = [add_months(Uk, -t) for t in range(1, periodo + 1)]
-                if all(m in ipc for m in meses_previos):
-                    F = Decimal("1")
-                    for m in meses_previos:
-                        F *= Decimal("1") + ipc[m]
-                    nuevo_valor = (valor_actual * F).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
-                    ajuste_valor = (nuevo_valor - valor_actual).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
-                    valor_periodo = nuevo_valor
-                    provisorio_periodo = False
+        valor_mes = None
+        ipc_pct = None
+        if mostrar_valor:
+            if offset == 0:
+                k = i // periodo
+                Uk = add_months(mes_inicio, k * periodo)
+                if k > 0:
+                    meses_previos = [add_months(Uk, -t) for t in range(1, periodo + 1)]
+                    if all(m in ipc for m in meses_previos):
+                        F = Decimal("1")
+                        for m in meses_previos:
+                            F *= Decimal("1") + ipc[m]
+                        nuevo_valor = (valor_actual * F).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+                        ajuste_valor = (nuevo_valor - valor_actual).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+                        valor_periodo = nuevo_valor
+                        provisorio_periodo = False
+                    else:
+                        valor_periodo = valor_actual
+                        provisorio_periodo = True
                 else:
                     valor_periodo = valor_actual
-                    provisorio_periodo = True
+                    provisorio_periodo = False
+                valor_mes = valor_actual
             else:
-                valor_periodo = valor_actual
-                provisorio_periodo = False
-            valor_mes = valor_actual
-        else:
-            valor_mes = valor_periodo
-        ipc_pct = None
-        if ym in ipc:
-            ipc_pct = (ipc[ym] * Decimal("100")).quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+                valor_mes = valor_periodo
+            if ym in ipc:
+                ipc_pct = (ipc[ym] * Decimal("100")).quantize(Decimal("0.1"), rounding=ROUND_HALF_UP)
+
         dt = datetime.strptime(ym, "%Y-%m")
         nombre_mes = f"{MESES_ES[dt.month - 1]} {dt.year}"
-        future = ym > hoy_ym
         tabla.append(
             {
                 "tipo": "mes",
                 "mes": nombre_mes,
                 "ym": ym,
-                "valor": float(valor_mes) if not future else None,
-                "provisorio": provisorio_periodo if not future else False,
+                "valor": float(valor_mes) if valor_mes is not None else None,
+                "provisorio": provisorio_periodo if (mostrar_valor and not future) else False,
                 "ipc": float(ipc_pct) if ipc_pct is not None else None,
                 "future": future,
+                "periodo": period_idx,
+                "offset": offset,
             }
         )
-        if ajuste_valor is not None:
+        if offset == 0 and i > 0:
             tabla.append(
                 {
                     "tipo": "ajuste",
                     "mes": f"Ajuste {nombre_mes}",
                     "ym": ym,
-                    "valor": float(ajuste_valor) if not future else None,
+                    "valor": float(ajuste_valor) if (mostrar_valor and ajuste_valor is not None) else None,
                     "future": future,
+                    "periodo": period_idx,
                 }
             )
-        if offset == periodo - 1 and not provisorio_periodo:
+        if offset == periodo - 1 and mostrar_valor and not provisorio_periodo:
             valor_actual = valor_periodo
     return tabla

--- a/templates/config.html
+++ b/templates/config.html
@@ -7,6 +7,11 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     #overlay {position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:1000;}
+    .periodo0.offset0 {background-color:#ffffff;}
+    .periodo0.offset1 {background-color:#f2f2f2;}
+    .periodo1.offset0 {background-color:#e7f5ff;}
+    .periodo1.offset1 {background-color:#d0ebff;}
+    .ajuste {background-color:#e6ffe6;}
   </style>
 </head>
 <body>
@@ -58,19 +63,16 @@
     <hr>
     <h2 class="h5 mt-4">Tabla de alquiler</h2>
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
-    <table class="table table-striped table-bordered">
+    <table class="table table-bordered">
       <thead>
-
-        <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
-
+        <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
       </thead>
       <tbody>
       {% for fila in tabla %}
-        <tr class="{% if fila.future %}opacity-50{% endif %}{% if fila.tipo == 'ajuste' %} fst-italic{% endif %}">
+        <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}">
           <td>{{ fila.mes }}</td>
           <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}</td>
-          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Tabla de alquiler</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    .periodo0.offset0 {background-color:#ffffff;}
+    .periodo0.offset1 {background-color:#f2f2f2;}
+    .periodo1.offset0 {background-color:#e7f5ff;}
+    .periodo1.offset1 {background-color:#d0ebff;}
+    .ajuste {background-color:#e6ffe6;}
+  </style>
 </head>
 <body>
   <nav class="navbar navbar-light bg-light mb-4">
@@ -19,18 +26,16 @@
     <h1 class="h4 mb-4">Tabla de alquiler</h1>
     {% if tabla %}
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
-    <table class="table table-striped table-bordered">
+    <table class="table table-bordered">
       <thead>
-        <tr><th>Mes</th><th>IPC</th><th>Valor</th><th></th></tr>
+        <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
       </thead>
       <tbody>
         {% for fila in tabla %}
-        <tr class="{% if fila.future %}opacity-50{% endif %}{% if fila.tipo == 'ajuste' %} fst-italic{% endif %}">
+        <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}">
           <td>{{ fila.mes }}</td>
-
           <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}</td>
-          <td>{% if fila.provisorio is defined and fila.provisorio %}<span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
## Summary
- keep rows for every month but only compute rent through next month
- remove fading so period and adjustment colors remain visible
- show upcoming adjustment rows even when values are pending

## Testing
- `python -m py_compile services/alquiler_service.py`
- `python -m py_compile routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8e53644e88332aab9888863408b43