### PR TITLE
Fix table row backgrounds by targeting cells

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -7,11 +7,11 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
     #overlay {position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:1000;}
-    .periodo0.offset0 {background-color:#ffffff;}
-    .periodo0.offset1 {background-color:#f2f2f2;}
-    .periodo1.offset0 {background-color:#e7f5ff;}
-    .periodo1.offset1 {background-color:#d0ebff;}
-    .ajuste {background-color:#e6ffe6;}
+    .periodo0.offset0 td {background-color:#ffffff;}
+    .periodo0.offset1 td {background-color:#f2f2f2;}
+    .periodo1.offset0 td {background-color:#e7f5ff;}
+    .periodo1.offset1 td {background-color:#d0ebff;}
+    .ajuste td {background-color:#e6ffe6;}
   </style>
 </head>
 <body>

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,11 +6,11 @@
   <title>Tabla de alquiler</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <style>
-    .periodo0.offset0 {background-color:#ffffff;}
-    .periodo0.offset1 {background-color:#f2f2f2;}
-    .periodo1.offset0 {background-color:#e7f5ff;}
-    .periodo1.offset1 {background-color:#d0ebff;}
-    .ajuste {background-color:#e6ffe6;}
+    .periodo0.offset0 td {background-color:#ffffff;}
+    .periodo0.offset1 td {background-color:#f2f2f2;}
+    .periodo1.offset0 td {background-color:#e7f5ff;}
+    .periodo1.offset1 td {background-color:#d0ebff;}
+    .ajuste td {background-color:#e6ffe6;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Scope CSS selectors to table cells so alternating colors render correctly
- Apply same cell-specific styling in the admin config table

## Testing
- `pytest`
- Rendered index template in a Flask context to ensure periodo and ajuste rows use new selectors

------
https://chatgpt.com/codex/tasks/task_e_68a8fa437600833291ce115aef5b5496