### PR TITLE
Highlight period boundaries in rental tables

### DIFF
--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -107,8 +107,11 @@ def generar_tabla_alquiler(
                     "valor": float(ajuste_valor) if (mostrar_valor and ajuste_valor is not None) else None,
                     "future": future,
                     "periodo": period_idx,
+                    "fin_periodo": True,
                 }
             )
         if offset == periodo - 1 and mostrar_valor and not provisorio_periodo:
             valor_actual = valor_periodo
+    if tabla:
+        tabla[-1]["fin_periodo"] = True
     return tabla

--- a/templates/config.html
+++ b/templates/config.html
@@ -9,10 +9,12 @@
     #overlay {position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(255,255,255,.8);display:none;align-items:center;justify-content:center;z-index:1000;}
     .periodo0.offset0 td {background-color:#ffffff;}
     .periodo0.offset1 td {background-color:#f2f2f2;}
-    .periodo1.offset0 td {background-color:#e7f5ff;}
-    .periodo1.offset1 td {background-color:#d0ebff;}
-    .ajuste td {background-color:#e6ffe6;}
-  </style>
+      .periodo1.offset0 td {background-color:#e7f5ff;}
+      .periodo1.offset1 td {background-color:#d0ebff;}
+      .ajuste td {background-color:#e6ffe6;}
+      .period-end td {border-bottom:2px solid #000 !important;}
+      .period-end + tr td {border-top:0 !important;}
+    </style>
 </head>
 <body>
   <nav class="navbar navbar-light bg-light mb-4">
@@ -68,12 +70,12 @@
         <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
       </thead>
       <tbody>
-      {% for fila in tabla %}
-        <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}">
-          <td>{{ fila.mes }}</td>
-          <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
-        </tr>
+        {% for fila in tabla %}
+          <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}{% if fila.fin_periodo %} period-end{% endif %}">
+            <td>{{ fila.mes }}</td>
+            <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+            <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          </tr>
       {% endfor %}
       </tbody>
     </table>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,10 +8,12 @@
   <style>
     .periodo0.offset0 td {background-color:#ffffff;}
     .periodo0.offset1 td {background-color:#f2f2f2;}
-    .periodo1.offset0 td {background-color:#e7f5ff;}
-    .periodo1.offset1 td {background-color:#d0ebff;}
-    .ajuste td {background-color:#e6ffe6;}
-  </style>
+      .periodo1.offset0 td {background-color:#e7f5ff;}
+      .periodo1.offset1 td {background-color:#d0ebff;}
+      .ajuste td {background-color:#e6ffe6;}
+      .period-end td {border-bottom:2px solid #000 !important;}
+      .period-end + tr td {border-top:0 !important;}
+    </style>
 </head>
 <body>
   <nav class="navbar navbar-light bg-light mb-4">
@@ -31,11 +33,11 @@
       </thead>
       <tbody>
         {% for fila in tabla %}
-        <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}">
-          <td>{{ fila.mes }}</td>
-          <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
-          <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
-        </tr>
+          <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}{% if fila.fin_periodo %} period-end{% endif %}">
+            <td>{{ fila.mes }}</td>
+            <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+            <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
+          </tr>
         {% endfor %}
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- mark period-ending rows in generated rental table data
- render a bold border after each period and its adjustment in rental and config views

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a900ab81288332ac196452ca579b64