### PR TITLE
Fix adjustment row placement and period flagging

### DIFF
--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -85,6 +85,20 @@ def generar_tabla_alquiler(
 
         dt = datetime.strptime(ym, "%Y-%m")
         nombre_mes = f"{MESES_ES[dt.month - 1]} {dt.year}"
+
+        if offset == 0 and i > 0:
+            tabla.append(
+                {
+                    "tipo": "ajuste",
+                    "mes": f"Ajuste {nombre_mes}",
+                    "ym": ym,
+                    "valor": float(ajuste_valor) if (mostrar_valor and ajuste_valor is not None) else None,
+                    "future": future,
+                    "periodo": period_idx,
+                    "fin_periodo": True,
+                }
+            )
+
         tabla.append(
             {
                 "tipo": "mes",
@@ -98,18 +112,6 @@ def generar_tabla_alquiler(
                 "offset": offset,
             }
         )
-        if offset == 0 and i > 0:
-            tabla.append(
-                {
-                    "tipo": "ajuste",
-                    "mes": f"Ajuste {nombre_mes}",
-                    "ym": ym,
-                    "valor": float(ajuste_valor) if (mostrar_valor and ajuste_valor is not None) else None,
-                    "future": future,
-                    "periodo": period_idx,
-                    "fin_periodo": True,
-                }
-            )
         if offset == periodo - 1 and mostrar_valor and not provisorio_periodo:
             valor_actual = valor_periodo
     if tabla:


### PR DESCRIPTION
## Summary
- insert adjustment rows before the first month in each new period
- ensure adjustment rows mark period end and last month does when no adjustment is present

## Testing
- `python -m pytest`
- `python - <<'PY'
from decimal import Decimal
from pprint import pprint
from services.alquiler_service import generar_tabla_alquiler

tabla = generar_tabla_alquiler(Decimal("1000"), "2024-01", periodo=2, meses=5)
for row in tabla:
    pprint(row)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68aa47190e908332aff2b9887747b3bf