### PR TITLE
Agregar columna de ajuste mensual

### DIFF
--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -77,7 +77,9 @@ def generar_tabla_alquiler(
                 else:
                     valor_periodo = valor_actual
                     provisorio_periodo = False
-                valor_mes = valor_actual
+                valor_mes = valor_periodo
+                if i > 0:
+                    tabla[-1]["fin_periodo"] = True
             else:
                 valor_mes = valor_periodo
             if ym in ipc:
@@ -86,30 +88,18 @@ def generar_tabla_alquiler(
         dt = datetime.strptime(ym, "%Y-%m")
         nombre_mes = f"{MESES_ES[dt.month - 1]} {dt.year}"
 
-        if offset == 0 and i > 0:
-            tabla.append(
-                {
-                    "tipo": "ajuste",
-                    "mes": f"Ajuste {nombre_mes}",
-                    "ym": ym,
-                    "valor": float(ajuste_valor) if (mostrar_valor and ajuste_valor is not None) else None,
-                    "future": future,
-                    "periodo": period_idx,
-                    "fin_periodo": True,
-                }
-            )
-
         tabla.append(
             {
-                "tipo": "mes",
                 "mes": nombre_mes,
                 "ym": ym,
                 "valor": float(valor_mes) if valor_mes is not None else None,
+                "ajuste": float(ajuste_valor) if (mostrar_valor and ajuste_valor is not None) else None,
                 "provisorio": provisorio_periodo if (mostrar_valor and not future) else False,
                 "ipc": float(ipc_pct) if ipc_pct is not None else None,
                 "future": future,
                 "periodo": period_idx,
                 "offset": offset,
+                "fin_periodo": False,
             }
         )
         if offset == periodo - 1 and mostrar_valor and not provisorio_periodo:

--- a/templates/config.html
+++ b/templates/config.html
@@ -11,7 +11,6 @@
     .periodo0.offset1 td {background-color:#f2f2f2;}
       .periodo1.offset0 td {background-color:#e7f5ff;}
       .periodo1.offset1 td {background-color:#d0ebff;}
-      .ajuste td {background-color:#e6ffe6;}
       .period-end td {border-bottom:2px solid #000 !important;}
       .period-end + tr td {border-top:0 !important;}
     </style>
@@ -67,13 +66,14 @@
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
     <table class="table table-bordered">
       <thead>
-        <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
+        <tr><th>Mes</th><th>IPC</th><th>Ajuste</th><th>Valor</th></tr>
       </thead>
       <tbody>
         {% for fila in tabla %}
-          <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}{% if fila.fin_periodo %} period-end{% endif %}">
+          <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% if fila.fin_periodo %} period-end{% endif %}">
             <td>{{ fila.mes }}</td>
             <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+            <td>{% if fila.ajuste is not none %}${{ '{:,.0f}'.format(fila.ajuste) }}{% endif %}</td>
             <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
           </tr>
       {% endfor %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,6 @@
     .periodo0.offset1 td {background-color:#f2f2f2;}
       .periodo1.offset0 td {background-color:#e7f5ff;}
       .periodo1.offset1 td {background-color:#d0ebff;}
-      .ajuste td {background-color:#e6ffe6;}
       .period-end td {border-bottom:2px solid #000 !important;}
       .period-end + tr td {border-top:0 !important;}
     </style>
@@ -28,13 +27,14 @@
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
     <table class="table table-bordered">
       <thead>
-        <tr><th>Mes</th><th>IPC</th><th>Valor</th></tr>
+        <tr><th>Mes</th><th>IPC</th><th>Ajuste</th><th>Valor</th></tr>
       </thead>
       <tbody>
         {% for fila in tabla %}
-          <tr class="{% if fila.tipo == 'ajuste' %}ajuste fst-italic{% else %}periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% endif %}{% if fila.fin_periodo %} period-end{% endif %}">
+          <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% if fila.fin_periodo %} period-end{% endif %}">
             <td>{{ fila.mes }}</td>
             <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
+            <td>{% if fila.ajuste is not none %}${{ '{:,.0f}'.format(fila.ajuste) }}{% endif %}</td>
             <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- mostrar el valor de ajuste de cada período en una nueva columna
- eliminar filas separadas de ajuste y estilos asociados

## Testing
- `python -m py_compile services/alquiler_service.py`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa4d388a6c8332b3e5de22e034dbf1