### PR TITLE
Remove period-end borders from tables

### DIFF
--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -78,8 +78,6 @@ def generar_tabla_alquiler(
                     valor_periodo = valor_actual
                     provisorio_periodo = False
                 valor_mes = valor_periodo
-                if i > 0:
-                    tabla[-1]["fin_periodo"] = True
             else:
                 valor_mes = valor_periodo
             if ym in ipc:
@@ -99,11 +97,8 @@ def generar_tabla_alquiler(
                 "future": future,
                 "periodo": period_idx,
                 "offset": offset,
-                "fin_periodo": False,
             }
         )
         if offset == periodo - 1 and mostrar_valor and not provisorio_periodo:
             valor_actual = valor_periodo
-    if tabla:
-        tabla[-1]["fin_periodo"] = True
     return tabla

--- a/templates/config.html
+++ b/templates/config.html
@@ -11,8 +11,6 @@
     .periodo0.offset1 td {background-color:#f2f2f2;}
       .periodo1.offset0 td {background-color:#e7f5ff;}
       .periodo1.offset1 td {background-color:#d0ebff;}
-      .period-end td {border-bottom:2px solid #000 !important;}
-      .period-end + tr td {border-top:0 !important;}
     </style>
 </head>
 <body>
@@ -70,7 +68,7 @@
       </thead>
       <tbody>
         {% for fila in tabla %}
-          <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% if fila.fin_periodo %} period-end{% endif %}">
+          <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}">
             <td>{{ fila.mes }}</td>
             <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
             <td>{% if fila.ajuste is not none %}${{ '{:,.0f}'.format(fila.ajuste) }}{% endif %}</td>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,8 +10,6 @@
     .periodo0.offset1 td {background-color:#f2f2f2;}
       .periodo1.offset0 td {background-color:#e7f5ff;}
       .periodo1.offset1 td {background-color:#d0ebff;}
-      .period-end td {border-bottom:2px solid #000 !important;}
-      .period-end + tr td {border-top:0 !important;}
     </style>
 </head>
 <body>
@@ -31,7 +29,7 @@
       </thead>
       <tbody>
         {% for fila in tabla %}
-          <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}{% if fila.fin_periodo %} period-end{% endif %}">
+          <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}">
             <td>{{ fila.mes }}</td>
             <td>{% if fila.ipc is defined and fila.ipc is not none %}{{ '{:.1f}'.format(fila.ipc)|replace('.', ',') }}%{% endif %}</td>
             <td>{% if fila.ajuste is not none %}${{ '{:,.0f}'.format(fila.ajuste) }}{% endif %}</td>


### PR DESCRIPTION
## Summary
- remove period-end tracking in rental table generation
- drop period-end CSS and classes in admin and index templates

## Testing
- `pytest`
- `python -m py_compile services/alquiler_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa54b785f88332a0bd6d4654eeb717