### PR TITLE
Fix rental table generation for future contract start dates

### DIFF
--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -28,10 +28,16 @@ def add_months(ym: str, m: int) -> str:
 
 
 def meses_hasta_fin_anio(mes_inicio: str) -> int:
-    """Return number of months from mes_inicio up to December of current year."""
+    """Return number of months from ``mes_inicio`` up to December of the relevant year."""
     inicio_dt = datetime.strptime(mes_inicio, "%Y-%m")
-    fin_dt = datetime(date.today().year, 12, 1)
-    return (fin_dt.year - inicio_dt.year) * 12 + (fin_dt.month - inicio_dt.month) + 1
+    hoy = date.today()
+    # Si el contrato empieza en el futuro usamos ese mismo año como límite para
+    # generar al menos un período completo. De otro modo nos quedaríamos sin
+    # filas y la tabla parecería vacía aunque la configuración exista.
+    fin_year = max(inicio_dt.year, hoy.year)
+    fin_dt = datetime(fin_year, 12, 1)
+    meses = (fin_dt.year - inicio_dt.year) * 12 + (fin_dt.month - inicio_dt.month) + 1
+    return max(meses, 0)
 
 
 def generar_tabla_alquiler(


### PR DESCRIPTION
## Summary
- update `meses_hasta_fin_anio` to cap the table horizon at the later of the contract year and the current year
- avoid returning an empty table when the contract starts in a future year so the configuration is properly reflected

## Testing
- python - <<'PY'
from services.alquiler_service import meses_hasta_fin_anio
print('2025-09 ->', meses_hasta_fin_anio('2025-09'))
print('2025-12 ->', meses_hasta_fin_anio('2025-12'))
print('2026-01 ->', meses_hasta_fin_anio('2026-01'))
PY

------
https://chatgpt.com/codex/tasks/task_e_68c9a0ec8b6483328a10efeab97990fa