### PR TITLE
Improve IPC table error handling

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -74,9 +74,13 @@
             <td>{% if fila.ajuste is not none %}${{ '{:,.0f}'.format(fila.ajuste) }}{% endif %}</td>
             <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
           </tr>
-      {% endfor %}
+        {% endfor %}
       </tbody>
     </table>
+    {% elif tabla_error %}
+    <hr>
+    <h2 class="h5 mt-4">Tabla de alquiler</h2>
+    <div class="alert alert-danger mt-3">Error cargando IPC. Intentalo nuevamente más tarde.</div>
     {% endif %}
   </div>
   <div id="overlay"><div class="spinner-border text-primary" role="status"></div></div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,6 +38,8 @@
         {% endfor %}
       </tbody>
     </table>
+    {% elif tabla_error %}
+    <div class="alert alert-danger">Error cargando IPC. Intentalo nuevamente más tarde.</div>
     {% else %}
     <div class="alert alert-info">No hay datos de configuración. Ingresá a <a href="{{ url_for('app.admin') }}">/adm</a> para cargarlos.</div>
     {% endif %}


### PR DESCRIPTION
## Summary
- add a helper to build the rent table that validates config inputs, logs unexpected failures, and keeps unexpected exceptions visible
- show a specific “Error cargando IPC” alert in the index and admin views when table generation fails while preserving the empty configuration notice

## Testing
- python -m compileall routes.py

------
https://chatgpt.com/codex/tasks/task_e_68c9d111aaa08332902c1b3f3a168b9e