### PR TITLE
Improve IPC CSV caching robustness

### DIFF
--- a/services/ipc_service.py
+++ b/services/ipc_service.py
@@ -1,5 +1,6 @@
 import csv
 import io
+import json
 import os
 import time
 import requests
@@ -9,23 +10,95 @@ from .config_service import CSV_URL
 
 
 CACHE_PATH = os.path.join("config", "ipc.csv")
+CACHE_METADATA_PATH = CACHE_PATH + ".meta"
 CACHE_TTL = 24 * 60 * 60  # 24 hours in seconds
+
+
+def _read_cached_rows():
+    with open(CACHE_PATH, "r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        raise RuntimeError("CSV vacío")
+    return rows[0], rows[1:]
+
+
+def _load_metadata():
+    try:
+        with open(CACHE_METADATA_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    return {}
+
+
+def _store_metadata(headers, preserve_existing=False):
+    metadata = {}
+    last_modified = headers.get("Last-Modified") if headers else None
+    etag = headers.get("ETag") if headers else None
+    if last_modified:
+        metadata["last_modified"] = last_modified
+    if etag:
+        metadata["etag"] = etag
+    if not metadata:
+        if preserve_existing:
+            return
+        if os.path.exists(CACHE_METADATA_PATH):
+            try:
+                os.remove(CACHE_METADATA_PATH)
+            except OSError:
+                pass
+        return
+    os.makedirs(os.path.dirname(CACHE_METADATA_PATH), exist_ok=True)
+    with open(CACHE_METADATA_PATH, "w", encoding="utf-8") as f:
+        json.dump(metadata, f)
 
 
 def leer_csv():
     """Leer y cachear el CSV del IPC."""
     # Usar archivo en caché si existe y es reciente
-    if os.path.exists(CACHE_PATH):
+    cache_exists = os.path.exists(CACHE_PATH)
+    if cache_exists:
         age = time.time() - os.path.getmtime(CACHE_PATH)
         if age < CACHE_TTL:
-            with open(CACHE_PATH, "r", encoding="utf-8") as f:
-                rows = list(csv.reader(f))
-            if not rows:
-                raise RuntimeError("CSV vacío")
-            return rows[0], rows[1:]
+            return _read_cached_rows()
+
+    metadata = _load_metadata() if cache_exists else {}
+    headers = {}
+    etag = metadata.get("etag")
+    last_modified = metadata.get("last_modified")
+    if etag:
+        headers["If-None-Match"] = etag
+    if last_modified:
+        headers["If-Modified-Since"] = last_modified
 
     # Descargar CSV y guardar en caché
-    r = requests.get(CSV_URL, timeout=20)
+    try:
+        if headers:
+            r = requests.get(CSV_URL, timeout=20, headers=headers)
+        else:
+            r = requests.get(CSV_URL, timeout=20)
+    except requests.RequestException:
+        if cache_exists:
+            return _read_cached_rows()
+        raise
+
+    if r.status_code == 304:
+        _store_metadata(r.headers, preserve_existing=True)
+        if cache_exists:
+            try:
+                os.utime(CACHE_PATH, None)
+            except FileNotFoundError:
+                pass
+            if os.path.exists(CACHE_METADATA_PATH):
+                try:
+                    os.utime(CACHE_METADATA_PATH, None)
+                except FileNotFoundError:
+                    pass
+            return _read_cached_rows()
+        raise RuntimeError("Respuesta 304 recibida sin caché disponible")
+
     r.raise_for_status()
     os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
     with open(CACHE_PATH, "wb") as f:
@@ -33,6 +106,7 @@ def leer_csv():
     rows = list(csv.reader(io.StringIO(r.content.decode("utf-8"))))
     if not rows:
         raise RuntimeError("CSV vacío")
+    _store_metadata(r.headers)
     return rows[0], rows[1:]
 
 

--- a/tests/test_ipc_service.py
+++ b/tests/test_ipc_service.py
@@ -1,0 +1,95 @@
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import requests
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services import ipc_service
+
+
+class LeerCsvTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.cache_path = os.path.join(self.tmpdir.name, "ipc.csv")
+        self.meta_path = self.cache_path + ".meta"
+
+        cache_patch = mock.patch.object(ipc_service, "CACHE_PATH", self.cache_path)
+        meta_patch = mock.patch.object(ipc_service, "CACHE_METADATA_PATH", self.meta_path)
+        self.addCleanup(cache_patch.stop)
+        self.addCleanup(meta_patch.stop)
+        cache_patch.start()
+        meta_patch.start()
+
+    def _write_cache(self, content):
+        with open(self.cache_path, "w", encoding="utf-8") as f:
+            f.write(content)
+
+    def _age_cache(self):
+        old = time.time() - (ipc_service.CACHE_TTL + 10)
+        os.utime(self.cache_path, (old, old))
+
+    def test_offline_uses_cached_data(self):
+        csv_content = "fecha,valor\n2020-01-01,1.50\n"
+        self._write_cache(csv_content)
+        self._age_cache()
+
+        with mock.patch.object(
+            ipc_service.requests,
+            "get",
+            side_effect=requests.RequestException("offline"),
+        ):
+            header, rows = ipc_service.leer_csv()
+
+        self.assertEqual(header, ["fecha", "valor"])
+        self.assertEqual(rows, [["2020-01-01", "1.50"]])
+
+    def test_not_modified_reuses_cache_and_sends_conditionals(self):
+        csv_content = "fecha,valor\n2020-01-01,1.50\n"
+        self._write_cache(csv_content)
+        self._age_cache()
+
+        metadata = {
+            "etag": "etag-value",
+            "last_modified": "Wed, 01 May 2024 10:00:00 GMT",
+        }
+        with open(self.meta_path, "w", encoding="utf-8") as f:
+            json.dump(metadata, f)
+
+        response = mock.Mock()
+        response.status_code = 304
+        response.headers = {
+            "ETag": metadata["etag"],
+            "Last-Modified": metadata["last_modified"],
+        }
+        response.raise_for_status.side_effect = AssertionError("304 should not raise")
+
+        with mock.patch.object(ipc_service.requests, "get", return_value=response) as mocked_get:
+            header, rows = ipc_service.leer_csv()
+
+        self.assertEqual(header, ["fecha", "valor"])
+        self.assertEqual(rows, [["2020-01-01", "1.50"]])
+        mocked_get.assert_called_once()
+        called_headers = mocked_get.call_args.kwargs.get("headers")
+        self.assertIsNotNone(called_headers)
+        self.assertEqual(called_headers.get("If-None-Match"), metadata["etag"])
+        self.assertEqual(called_headers.get("If-Modified-Since"), metadata["last_modified"])
+        # Cache timestamp should be refreshed after a 304
+        self.assertLess(time.time() - os.path.getmtime(self.cache_path), 5)
+        with open(self.meta_path, "r", encoding="utf-8") as f:
+            stored_metadata = json.load(f)
+        self.assertEqual(stored_metadata.get("etag"), metadata["etag"])
+        self.assertEqual(stored_metadata.get("last_modified"), metadata["last_modified"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle network failures by falling back to cached IPC CSV data and persist cache metadata
- add conditional request support using cached ETag/Last-Modified headers to skip redundant downloads
- add unit tests covering offline cache reuse and 304 Not Modified responses

## Testing
- python -m unittest tests.test_ipc_service

------
https://chatgpt.com/codex/tasks/task_e_68c9d13314588332824dcf9fca510289