### PR TITLE
Improve IPC error visibility and messaging

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -58,7 +58,7 @@
       </div>
       <button type="submit" class="btn btn-primary">Guardar</button>
     </form>
-    {% if tabla %}
+    {% if tabla is not none %}
     <hr>
     <h2 class="h5 mt-4">Tabla de alquiler</h2>
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
@@ -67,6 +67,7 @@
         <tr><th>Mes</th><th>IPC</th><th>Ajuste</th><th>Valor</th></tr>
       </thead>
       <tbody>
+        {% if tabla %}
         {% for fila in tabla %}
           <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}">
             <td>{{ fila.mes }}</td>
@@ -75,8 +76,17 @@
             <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
           </tr>
       {% endfor %}
+        {% else %}
+          <tr><td colspan="4" class="text-center">Sin datos disponibles</td></tr>
+        {% endif %}
       </tbody>
     </table>
+    {% elif tabla_error %}
+    <hr>
+    <div class="alert alert-danger mt-4">Error cargando IPC.</div>
+    {% elif not tiene_config %}
+    <hr>
+    <div class="alert alert-info mt-4">No hay datos de configuración. Completá el formulario para generarlos.</div>
     {% endif %}
   </div>
   <div id="overlay"><div class="spinner-border text-primary" role="status"></div></div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,13 +21,14 @@
     </div>
   </nav>
   <div class="container">
-    {% if tabla %}
+    {% if tabla is not none %}
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
     <table class="table table-bordered">
       <thead>
         <tr><th>Mes</th><th>IPC</th><th>Ajuste</th><th>Valor</th></tr>
       </thead>
       <tbody>
+        {% if tabla %}
         {% for fila in tabla %}
           <tr class="periodo{{ fila.periodo % 2 }} offset{{ fila.offset % 2 }}">
             <td>{{ fila.mes }}</td>
@@ -36,9 +37,14 @@
             <td>{% if fila.valor is not none %}${{ '{:,.0f}'.format(fila.valor) }}{% endif %}{% if fila.provisorio is defined and fila.provisorio %} <span class="badge bg-warning text-dark">Provisorio</span>{% endif %}</td>
           </tr>
         {% endfor %}
+        {% else %}
+          <tr><td colspan="4" class="text-center">Sin datos disponibles</td></tr>
+        {% endif %}
       </tbody>
     </table>
-    {% else %}
+    {% elif tabla_error %}
+    <div class="alert alert-danger">Error cargando IPC.</div>
+    {% elif not tiene_config %}
     <div class="alert alert-info">No hay datos de configuración. Ingresá a <a href="{{ url_for('app.admin') }}">/adm</a> para cargarlos.</div>
     {% endif %}
   </div>


### PR DESCRIPTION
## Summary
- limit the IPC table generation handlers to expected validation exceptions and log unexpected failures
- surface IPC loading failures in the index and admin templates with a dedicated error message
- adjust admin configuration saving to report validation problems without hiding unexpected errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9d13be87c8332a6bc49a93fbe8315