### PR TITLE
Improve IPC caching resilience and surface status in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
 config/config.json
 config/users.json
+config/ipc.meta.json
 __pycache__/

--- a/services/alquiler_service.py
+++ b/services/alquiler_service.py
@@ -28,16 +28,26 @@ def add_months(ym: str, m: int) -> str:
 
 
 def meses_hasta_fin_anio(mes_inicio: str) -> int:
-    """Return number of months from mes_inicio up to December of current year."""
+    """Return number of months from ``mes_inicio`` up to December of the relevant year."""
     inicio_dt = datetime.strptime(mes_inicio, "%Y-%m")
-    fin_dt = datetime(date.today().year, 12, 1)
-    return (fin_dt.year - inicio_dt.year) * 12 + (fin_dt.month - inicio_dt.month) + 1
+    hoy = date.today()
+    # Si el contrato empieza en el futuro usamos ese mismo año como límite para
+    # generar al menos un período completo. De otro modo nos quedaríamos sin
+    # filas y la tabla parecería vacía aunque la configuración exista.
+    fin_year = max(inicio_dt.year, hoy.year)
+    fin_dt = datetime(fin_year, 12, 1)
+    meses = (fin_dt.year - inicio_dt.year) * 12 + (fin_dt.month - inicio_dt.month) + 1
+    return max(meses, 0)
 
 
 def generar_tabla_alquiler(
-    alquiler_base: Decimal, mes_inicio: str, periodo: int, meses: int | None = None
+    alquiler_base: Decimal,
+    mes_inicio: str,
+    periodo: int,
+    meses: int | None = None,
+    ipc_data: dict[str, Decimal] | None = None,
 ):
-    ipc = ipc_dict()
+    ipc = ipc_data if ipc_data is not None else ipc_dict()
     hoy_ym = date.today().strftime("%Y-%m")
     max_ym = add_months(hoy_ym, 1)
     if meses is None:

--- a/services/ipc_service.py
+++ b/services/ipc_service.py
@@ -1,39 +1,142 @@
 import csv
 import io
+import json
+import logging
 import os
 import time
+
 import requests
 from decimal import Decimal, InvalidOperation
-from datetime import datetime
+from datetime import datetime, timezone
+
 from .config_service import CSV_URL
 
 
 CACHE_PATH = os.path.join("config", "ipc.csv")
 CACHE_TTL = 24 * 60 * 60  # 24 hours in seconds
+CACHE_META_PATH = os.path.join("config", "ipc.meta.json")
+
+logger = logging.getLogger(__name__)
+
+
+def _cache_last_modified() -> datetime | None:
+    """Return the datetime of the cached CSV if it exists."""
+
+    try:
+        ts = os.path.getmtime(CACHE_PATH)
+    except OSError:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc)
+
+
+def _load_cache_rows() -> list[list[str]]:
+    """Load cached CSV rows."""
+
+    with open(CACHE_PATH, "r", encoding="utf-8") as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        raise RuntimeError("CSV vacío")
+    return rows
+
+
+def _read_meta() -> dict:
+    try:
+        with open(CACHE_META_PATH, "r", encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError, ValueError):
+        return {}
+
+
+def _write_meta(meta: dict) -> None:
+    os.makedirs(os.path.dirname(CACHE_META_PATH), exist_ok=True)
+    with open(CACHE_META_PATH, "w", encoding="utf-8") as fh:
+        json.dump(meta, fh)
 
 
 def leer_csv():
     """Leer y cachear el CSV del IPC."""
-    # Usar archivo en caché si existe y es reciente
-    if os.path.exists(CACHE_PATH):
-        age = time.time() - os.path.getmtime(CACHE_PATH)
-        if age < CACHE_TTL:
-            with open(CACHE_PATH, "r", encoding="utf-8") as f:
-                rows = list(csv.reader(f))
-            if not rows:
-                raise RuntimeError("CSV vacío")
-            return rows[0], rows[1:]
+    meta = _read_meta()
+    cache_exists = os.path.exists(CACHE_PATH)
+    cache_age = None
+    if cache_exists:
+        cache_age = time.time() - os.path.getmtime(CACHE_PATH)
 
-    # Descargar CSV y guardar en caché
-    r = requests.get(CSV_URL, timeout=20)
-    r.raise_for_status()
-    os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
-    with open(CACHE_PATH, "wb") as f:
-        f.write(r.content)
-    rows = list(csv.reader(io.StringIO(r.content.decode("utf-8"))))
-    if not rows:
-        raise RuntimeError("CSV vacío")
-    return rows[0], rows[1:]
+    status = {
+        "source": CSV_URL,
+        "used_cache": False,
+        "updated": False,
+        "stale": False,
+        "error": None,
+        "etag": meta.get("etag"),
+        "last_modified_header": meta.get("last_modified"),
+        "last_cached_at": _cache_last_modified(),
+        "last_checked_at": None,
+    }
+
+    if cache_exists and (cache_age is not None) and cache_age < CACHE_TTL:
+        rows = _load_cache_rows()
+        status["used_cache"] = True
+        return rows[0], rows[1:], status
+
+    headers = {}
+    if meta.get("etag"):
+        headers["If-None-Match"] = meta["etag"]
+    if meta.get("last_modified"):
+        headers["If-Modified-Since"] = meta["last_modified"]
+
+    try:
+        status["last_checked_at"] = datetime.now(timezone.utc)
+        response = requests.get(CSV_URL, timeout=20, headers=headers or None)
+        if response.status_code == 304 and cache_exists:
+            rows = _load_cache_rows()
+            status["used_cache"] = True
+            status["stale"] = False
+            return rows[0], rows[1:], status
+
+        response.raise_for_status()
+        text = response.content.decode("utf-8")
+        rows = list(csv.reader(io.StringIO(text)))
+        if not rows:
+            raise RuntimeError("CSV vacío")
+        os.makedirs(os.path.dirname(CACHE_PATH), exist_ok=True)
+        with open(CACHE_PATH, "wb") as f:
+            f.write(response.content)
+        fetched_at = datetime.now(timezone.utc)
+        status.update(
+            {
+                "used_cache": False,
+                "updated": True,
+                "stale": False,
+                "last_cached_at": fetched_at,
+                "etag": response.headers.get("ETag"),
+                "last_modified_header": response.headers.get("Last-Modified"),
+                "last_checked_at": fetched_at,
+            }
+        )
+        meta_to_store = {
+            "etag": status["etag"],
+            "last_modified": status["last_modified_header"],
+            "fetched_at": fetched_at.isoformat(),
+        }
+        _write_meta(meta_to_store)
+        return rows[0], rows[1:], status
+    except requests.RequestException as exc:
+        if cache_exists:
+            logger.warning(
+                "No se pudo actualizar el CSV del IPC: %s. Se utilizarán los datos cacheados.",
+                exc,
+            )
+            rows = _load_cache_rows()
+            status.update(
+                {
+                    "used_cache": True,
+                    "updated": False,
+                    "stale": cache_age is not None and cache_age >= CACHE_TTL,
+                    "error": str(exc),
+                }
+            )
+            return rows[0], rows[1:], status
+        raise
 
 
 def parse_fechas(f):
@@ -44,9 +147,9 @@ def parse_fechas(f):
         return f[:7]
 
 
-def ipc_dict():
-    """Return a dict {"YYYY-MM": Decimal(proportion)}."""
-    _, filas = leer_csv()
+def ipc_dict_with_status():
+    """Return IPC dictionary along with cache status metadata."""
+    _, filas, status = leer_csv()
     out = {}
     prev_indice_dec = None
     for row in filas:
@@ -68,4 +171,10 @@ def ipc_dict():
         if ipc_prop_dec is not None:
             out[mes] = ipc_prop_dec
         prev_indice_dec = indice_dec
-    return out
+    return out, status
+
+
+def ipc_dict():
+    """Return a dict {"YYYY-MM": Decimal(proportion)} without metadata."""
+    data, _ = ipc_dict_with_status()
+    return data

--- a/templates/config.html
+++ b/templates/config.html
@@ -58,10 +58,22 @@
       </div>
       <button type="submit" class="btn btn-primary">Guardar</button>
     </form>
+    {% if tabla_error %}
+    <div class="alert alert-danger mt-3" role="alert">{{ tabla_error }}</div>
+    {% endif %}
     {% if tabla %}
     <hr>
     <h2 class="h5 mt-4">Tabla de alquiler</h2>
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
+    {% if ipc_status and ipc_status.last_cached_at_text %}
+    <div class="text-end text-muted mb-2">Última actualización del IPC: {{ ipc_status.last_cached_at_text }}</div>
+    {% endif %}
+    {% if ipc_status and ipc_status.error %}
+    <div class="alert alert-warning" role="alert">
+      No se pudo actualizar el IPC. Se muestran los datos guardados del
+      {% if ipc_status.last_cached_at_text %}{{ ipc_status.last_cached_at_text }}{% else %}archivo en caché{% endif %}.
+    </div>
+    {% endif %}
     <table class="table table-bordered">
       <thead>
         <tr><th>Mes</th><th>IPC</th><th>Ajuste</th><th>Valor</th></tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,8 +21,20 @@
     </div>
   </nav>
   <div class="container">
+    {% if tabla_error %}
+    <div class="alert alert-danger" role="alert">{{ tabla_error }}</div>
+    {% endif %}
     {% if tabla %}
+    {% if ipc_status and ipc_status.error %}
+    <div class="alert alert-warning" role="alert">
+      No se pudo actualizar el IPC. Se muestran los datos guardados del
+      {% if ipc_status.last_cached_at_text %}{{ ipc_status.last_cached_at_text }}{% else %}archivo en caché{% endif %}.
+    </div>
+    {% endif %}
     <div class="text-end mb-2">Fecha de hoy: {{ fecha_hoy }}</div>
+    {% if ipc_status and ipc_status.last_cached_at_text %}
+    <div class="text-end text-muted mb-2">Última actualización del IPC: {{ ipc_status.last_cached_at_text }}</div>
+    {% endif %}
     <table class="table table-bordered">
       <thead>
         <tr><th>Mes</th><th>IPC</th><th>Ajuste</th><th>Valor</th></tr>
@@ -38,7 +50,7 @@
         {% endfor %}
       </tbody>
     </table>
-    {% else %}
+    {% elif not tabla_error %}
     <div class="alert alert-info">No hay datos de configuración. Ingresá a <a href="{{ url_for('app.admin') }}">/adm</a> para cargarlos.</div>
     {% endif %}
   </div>


### PR DESCRIPTION
## Summary
- make the IPC CSV loader reuse cached data on failures, persist conditional request metadata, and report cache status information
- allow rental table generation to accept preloaded IPC data and expose cache status through the routes and templates with user-facing warnings and last-update timestamps
- ignore the generated IPC metadata file to avoid accidental commits

## Testing
- python -m compileall routes.py services templates

------
https://chatgpt.com/codex/tasks/task_e_68c9a0ec8b6483328a10efeab97990fa