### PR TITLE
Fix duplicate keyword argument when rendering config

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -241,7 +241,6 @@ def admin():
             ipc_status=_format_ipc_status(ipc_status),
             fecha_hoy=date.today().strftime("%d-%m-%Y"),
             users=users,
-            tabla_error=tabla_error,
             tiene_config=tiene_config,
         )
 


### PR DESCRIPTION
## Summary
- remove the duplicate `tabla_error` keyword argument when rendering the admin configuration template to avoid syntax errors at import time

## Testing
- pytest *(fails: tests/test_ipc_service.py::LeerCsvTests raises ValueError because leer_csv returns three values)*

------
https://chatgpt.com/codex/tasks/task_e_68c9d5d9a5a8833294dd07467ea5e691