### PR TITLE
Define tiene_config flag for admin view

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -217,7 +217,8 @@ def admin():
         ipc_status = None
         base_raw = config.get("alquiler_base")
         inicio_raw = config.get("fecha_inicio_contrato", "")
-        if base_raw and inicio_raw:
+        tiene_config = bool(base_raw and inicio_raw)
+        if tiene_config:
             try:
                 base = Decimal(base_raw)
                 inicio = inicio_raw[:7]


### PR DESCRIPTION
## Summary
- compute the `tiene_config` flag in the admin view based on the stored configuration
- pass the flag to the template so the admin panel can render without raising a NameError

## Testing
- pytest *(fails: tests expect `leer_csv` to return two values instead of three)*

------
https://chatgpt.com/codex/tasks/task_e_68c9eab7ee148332a6317713d985db3d