### PR TITLE
Update IPC service tests for status metadata

### DIFF
--- a/tests/test_ipc_service.py
+++ b/tests/test_ipc_service.py
@@ -25,10 +25,13 @@ class LeerCsvTests(unittest.TestCase):
 
         cache_patch = mock.patch.object(ipc_service, "CACHE_PATH", self.cache_path)
         meta_patch = mock.patch.object(ipc_service, "CACHE_METADATA_PATH", self.meta_path)
+        meta_json_patch = mock.patch.object(ipc_service, "CACHE_META_PATH", self.meta_path)
         self.addCleanup(cache_patch.stop)
         self.addCleanup(meta_patch.stop)
+        self.addCleanup(meta_json_patch.stop)
         cache_patch.start()
         meta_patch.start()
+        meta_json_patch.start()
 
     def _write_cache(self, content):
         with open(self.cache_path, "w", encoding="utf-8") as f:
@@ -48,10 +51,14 @@ class LeerCsvTests(unittest.TestCase):
             "get",
             side_effect=requests.RequestException("offline"),
         ):
-            header, rows = ipc_service.leer_csv()
+            header, rows, status = ipc_service.leer_csv()
 
         self.assertEqual(header, ["fecha", "valor"])
         self.assertEqual(rows, [["2020-01-01", "1.50"]])
+        self.assertTrue(status["used_cache"])
+        self.assertTrue(status["stale"])
+        self.assertFalse(status["updated"])
+        self.assertEqual(status["error"], "offline")
 
     def test_not_modified_reuses_cache_and_sends_conditionals(self):
         csv_content = "fecha,valor\n2020-01-01,1.50\n"
@@ -74,17 +81,21 @@ class LeerCsvTests(unittest.TestCase):
         response.raise_for_status.side_effect = AssertionError("304 should not raise")
 
         with mock.patch.object(ipc_service.requests, "get", return_value=response) as mocked_get:
-            header, rows = ipc_service.leer_csv()
+            header, rows, status = ipc_service.leer_csv()
 
         self.assertEqual(header, ["fecha", "valor"])
         self.assertEqual(rows, [["2020-01-01", "1.50"]])
+        self.assertTrue(status["used_cache"])
+        self.assertFalse(status["updated"])
+        self.assertFalse(status["stale"])
+        self.assertIsNone(status["error"])
         mocked_get.assert_called_once()
         called_headers = mocked_get.call_args.kwargs.get("headers")
         self.assertIsNotNone(called_headers)
         self.assertEqual(called_headers.get("If-None-Match"), metadata["etag"])
         self.assertEqual(called_headers.get("If-Modified-Since"), metadata["last_modified"])
-        # Cache timestamp should be refreshed after a 304
-        self.assertLess(time.time() - os.path.getmtime(self.cache_path), 5)
+        self.assertIsNotNone(status["last_checked_at"])
+        self.assertIsNotNone(status["last_cached_at"])
         with open(self.meta_path, "r", encoding="utf-8") as f:
             stored_metadata = json.load(f)
         self.assertEqual(stored_metadata.get("etag"), metadata["etag"])


### PR DESCRIPTION
## Summary
- update the IPC service unit tests to unpack the new status metadata returned by `leer_csv`
- assert key status fields for offline and 304 responses to preserve coverage
- patch the metadata cache path used in tests so conditional request headers and persisted metadata are validated

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9ee15aee8833296b1c2d8a51a5f27