### PR TITLE
Load CSV URL from .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 ADMIN_USER=admin
 ADMIN_PASS=admin
 SECRET_KEY=change_me
+CSV_URL="https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run -d --name ipc-api -p 8000:8000 ipc-api
 
 ## Configuración
 Variables de entorno admitidas:
-- `CSV_URL`: URL del CSV a usar (por defecto la oficial del INDEC).
+- `CSV_URL`: URL del CSV a usar (por defecto la oficial del INDEC). También se admite la variable legacy `CSV_DATOS`.
 - `ADMIN_USER` y `ADMIN_PASS`: credenciales para `/adm` (por defecto `admin`/`admin`).
 - `SECRET_KEY`: clave de sesión de Flask.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,6 @@ services:
     container_name: alquiler-IPC
 
     env_file: .env
-    environment:
-      # Podés overridear la URL si fuese necesario
-      CSV_URL: "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv"
     expose:
       - "8000"
     volumes:

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -6,7 +6,10 @@ load_dotenv()
 
 CSV_URL = os.getenv(
     "CSV_URL",
-    "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv",
+    os.getenv(
+        "CSV_DATOS",
+        "https://infra.datos.gob.ar/catalog/sspm/dataset/145/distribution/145.3/download/indice-precios-al-consumidor-nivel-general-base-diciembre-2016-mensual.csv",
+    ),
 )
 ADMIN_USER = os.getenv("ADMIN_USER", "admin")
 ADMIN_PASS = os.getenv("ADMIN_PASS", "admin")


### PR DESCRIPTION
## Summary
- stop hardcoding the CSV URL in docker-compose and rely on values from the .env file
- add the default CSV URL to the example .env and allow the legacy CSV_DATOS variable in configuration
- document the CSV environment variable behaviour in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f38f33348332abfc61960bdc049c