### PR TITLE
Adjust IPC cache freshness boundary at day 15

### DIFF
--- a/services/ipc_service.py
+++ b/services/ipc_service.py
@@ -65,7 +65,7 @@ def _is_cache_stale(latest_month: str | None, *, today: date | None = None) -> b
     elif isinstance(today, datetime):
         today = today.date()
 
-    months_back = 1 if today.day > 15 else 2
+    months_back = 1 if today.day >= 15 else 2
     total_months = today.year * 12 + (today.month - 1)
     required_total = total_months - months_back
     required_year, required_month_index = divmod(required_total, 12)


### PR DESCRIPTION
## Summary
- treat the 15th as the publication cutoff so the prior month's IPC becomes mandatory from that day forward
- expand IPC service tests to cover the 15th-day freshness rules, including direct `_is_cache_stale` checks

## Testing
- pytest tests/test_ipc_service.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f62550908332a2addeaaaadc4883