### PR TITLE
Prevent admin logout during admin actions

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -25,11 +25,11 @@
   <div class="container">
     <div id="alert-placeholder"></div>
     <h2 class="h5">Usuarios</h2>
-    <form class="mb-3 d-flex" action="{{ url_for('app.admin_add_user') }}" method="post">
+    <form id="add-user-form" class="mb-3 d-flex" action="{{ url_for('app.admin_add_user') }}" method="post">
       <input type="text" class="form-control me-2" name="new_user" placeholder="Nombre">
       <button class="btn btn-primary" type="submit">Agregar usuario</button>
     </form>
-    <form class="mb-4 d-flex" action="{{ url_for('app.admin_delete_user') }}" method="post">
+    <form id="delete-user-form" class="mb-4 d-flex" action="{{ url_for('app.admin_delete_user') }}" method="post">
       <select class="form-select me-2" name="user">
         {% for u in users %}
         <option value="{{ u }}">{{ u }}</option>
@@ -105,12 +105,25 @@
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script>
     const form = document.getElementById('config-form');
+    let skipLogoutOnUnload = false;
     const overlay = document.getElementById('overlay');
     const alertPlaceholder = document.getElementById('alert-placeholder');
     function showAlert(message, type) {
       const wrapper = document.createElement('div');
       wrapper.innerHTML = `<div class="alert alert-${type} alert-dismissible" role="alert">${message}<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>`;
       alertPlaceholder.append(wrapper);
+    }
+    const addUserForm = document.getElementById('add-user-form');
+    if (addUserForm) {
+      addUserForm.addEventListener('submit', () => {
+        skipLogoutOnUnload = true;
+      });
+    }
+    const deleteUserForm = document.getElementById('delete-user-form');
+    if (deleteUserForm) {
+      deleteUserForm.addEventListener('submit', () => {
+        skipLogoutOnUnload = true;
+      });
     }
     form.addEventListener('submit', function(e) {
       e.preventDefault();
@@ -125,6 +138,7 @@
       }).then(data => {
         overlay.style.display = 'none';
         showAlert('Configuración guardada correctamente', 'success');
+        skipLogoutOnUnload = true;
         setTimeout(() => window.location.reload(), 500);
       }).catch(() => {
         overlay.style.display = 'none';
@@ -132,7 +146,9 @@
       });
     });
     window.addEventListener('beforeunload', () => {
-      navigator.sendBeacon('{{ url_for('app.logout') }}', '');
+      if (!skipLogoutOnUnload && navigator.sendBeacon) {
+        navigator.sendBeacon('{{ url_for('app.logout') }}', '');
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- prevent the beforeunload handler from logging out admins while submitting add/delete user forms
- mark submissions that trigger a page reload to skip the automatic logout beacon

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9fd7c9b2c8332b684826b0531fd4c