### PR TITLE
Permitir configurar URL del CSV del IPC

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -18,7 +18,7 @@ from services.config_service import (
     save_config,
     ADMIN_USER,
     ADMIN_PASS,
-    CSV_URL,
+    get_csv_url,
 )
 from services.ipc_service import leer_csv, parse_fechas, ipc_dict_with_status
 from services.alquiler_service import generar_tabla_alquiler, meses_hasta_fin_anio
@@ -101,7 +101,7 @@ def ipc_ultimos():
         cache_info["last_checked_at"] = status["last_checked_at"].isoformat()
     return jsonify(
         {
-            "source": CSV_URL,
+            "source": status.get("source") or get_csv_url(),
             "last_month": last_date,
             "count": len(out),
             "data": out,
@@ -192,6 +192,7 @@ def admin():
                     "alquiler_base": request.form.get("alquiler_base", ""),
                     "fecha_inicio_contrato": request.form.get("fecha_inicio_contrato", ""),
                     "periodo_actualizacion_meses": request.form.get("periodo_actualizacion_meses", ""),
+                    "csv_url": request.form.get("csv_url", "").strip(),
                 }
             )
             try:

--- a/services/config_service.py
+++ b/services/config_service.py
@@ -1,10 +1,12 @@
-import os
 import json
+import os
+from typing import Any, Dict
+
 from dotenv import load_dotenv
 
 load_dotenv()
 
-CSV_URL = os.getenv(
+DEFAULT_CSV_URL = os.getenv(
     "CSV_URL",
     os.getenv(
         "CSV_DATOS",
@@ -15,23 +17,79 @@ ADMIN_USER = os.getenv("ADMIN_USER", "admin")
 ADMIN_PASS = os.getenv("ADMIN_PASS", "admin")
 CONFIG_FILE = os.path.join(os.path.dirname(__file__), "..", "config", "config.json")
 
-
-def load_config():
-    """Load configuration from JSON file."""
-    path = os.path.abspath(CONFIG_FILE)
-    if os.path.exists(path):
-        with open(path, "r", encoding="utf-8") as fh:
-            return json.load(fh)
-    return {
-        "alquiler_base": "",
-        "fecha_inicio_contrato": "",
-        "periodo_actualizacion_meses": "",
-    }
+_DEFAULT_CONFIG: Dict[str, Any] = {
+    "alquiler_base": "",
+    "fecha_inicio_contrato": "",
+    "periodo_actualizacion_meses": "",
+    "csv_url": "",
+}
 
 
-def save_config(data):
+def _config_path() -> str:
+    return os.path.abspath(CONFIG_FILE)
+
+
+def _read_raw_config() -> Dict[str, Any]:
+    """Return the raw config from disk without applying defaults."""
+
+    path = _config_path()
+    if not os.path.exists(path):
+        return {}
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration applying defaults for missing values."""
+
+    data = _DEFAULT_CONFIG.copy()
+    raw = _read_raw_config()
+    data.update(raw)
+    csv_url = raw.get("csv_url") if isinstance(raw, dict) else ""
+    if isinstance(csv_url, str):
+        csv_url = csv_url.strip()
+    elif csv_url is not None:
+        csv_url = str(csv_url)
+    else:
+        csv_url = ""
+    if csv_url:
+        data["csv_url"] = csv_url
+    else:
+        data["csv_url"] = DEFAULT_CSV_URL
+    return data
+
+
+def get_csv_url() -> str:
+    """Return the configured CSV URL falling back to environment defaults."""
+
+    raw = _read_raw_config()
+    csv_url = raw.get("csv_url") if isinstance(raw, dict) else ""
+    if isinstance(csv_url, str):
+        csv_url = csv_url.strip()
+    elif csv_url is not None:
+        csv_url = str(csv_url)
+    else:
+        csv_url = ""
+    if csv_url:
+        return csv_url
+    return DEFAULT_CSV_URL
+
+
+def save_config(data: Dict[str, Any]) -> None:
     """Persist configuration to JSON file."""
-    path = os.path.abspath(CONFIG_FILE)
+
+    path = _config_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
+    to_store: Any
+    if isinstance(data, dict):
+        to_store = data.copy()
+        csv_url_value = to_store.get("csv_url")
+        if isinstance(csv_url_value, str):
+            to_store["csv_url"] = csv_url_value.strip()
+    else:
+        to_store = data
     with open(path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh)
+        json.dump(to_store, fh)

--- a/services/ipc_service.py
+++ b/services/ipc_service.py
@@ -9,7 +9,7 @@ import requests
 from decimal import Decimal, InvalidOperation
 from datetime import datetime, timezone, date
 
-from .config_service import CSV_URL
+from . import config_service
 
 
 CACHE_PATH = os.path.join("config", "ipc.csv")
@@ -90,6 +90,7 @@ def _write_meta(meta: dict) -> None:
 
 def leer_csv():
     """Leer y cachear el CSV del IPC."""
+    csv_url = config_service.get_csv_url()
     meta = _read_meta()
     cache_exists = os.path.exists(CACHE_PATH)
     cache_age = None
@@ -97,7 +98,7 @@ def leer_csv():
         cache_age = time.time() - os.path.getmtime(CACHE_PATH)
 
     status = {
-        "source": CSV_URL,
+        "source": csv_url,
         "used_cache": False,
         "updated": False,
         "stale": False,
@@ -130,7 +131,7 @@ def leer_csv():
 
     try:
         status["last_checked_at"] = datetime.now(timezone.utc)
-        response = requests.get(CSV_URL, timeout=20, headers=headers or None)
+        response = requests.get(csv_url, timeout=20, headers=headers or None)
         if response.status_code == 304 and cache_exists:
             if cached_header is None or cached_rows is None:
                 rows = _load_cache_rows()

--- a/templates/config.html
+++ b/templates/config.html
@@ -56,6 +56,10 @@
         </select>
 
       </div>
+      <div class="mb-3">
+        <label class="form-label" for="csv-url-input">URL del CSV del IPC</label>
+        <input type="url" class="form-control" id="csv-url-input" name="csv_url" value="{{ config.csv_url }}" placeholder="https://...">
+      </div>
       <button type="submit" class="btn btn-primary">Guardar</button>
     </form>
     {% if tabla_error %}

--- a/tests/test_ipc_service.py
+++ b/tests/test_ipc_service.py
@@ -24,16 +24,20 @@ class LeerCsvTests(unittest.TestCase):
         self.addCleanup(self.tmpdir.cleanup)
         self.cache_path = os.path.join(self.tmpdir.name, "ipc.csv")
         self.meta_path = self.cache_path + ".meta"
+        self.config_path = os.path.join(self.tmpdir.name, "config.json")
 
         cache_patch = mock.patch.object(ipc_service, "CACHE_PATH", self.cache_path)
         meta_patch = mock.patch.object(ipc_service, "CACHE_METADATA_PATH", self.meta_path)
         meta_json_patch = mock.patch.object(ipc_service, "CACHE_META_PATH", self.meta_path)
+        config_patch = mock.patch("services.config_service.CONFIG_FILE", self.config_path)
         self.addCleanup(cache_patch.stop)
         self.addCleanup(meta_patch.stop)
         self.addCleanup(meta_json_patch.stop)
+        self.addCleanup(config_patch.stop)
         cache_patch.start()
         meta_patch.start()
         meta_json_patch.start()
+        config_patch.start()
 
     def _write_cache(self, content):
         with open(self.cache_path, "w", encoding="utf-8") as f:
@@ -143,6 +147,27 @@ class LeerCsvTests(unittest.TestCase):
         self.assertEqual(rows, [["2024-02-01", "1.50"]])
         self.assertTrue(status["used_cache"])
         self.assertFalse(status["stale"])
+
+    def test_leer_csv_uses_configured_url(self):
+        custom_url = "https://example.com/custom-ipc.csv"
+        with open(self.config_path, "w", encoding="utf-8") as f:
+            json.dump({"csv_url": custom_url}, f)
+
+        response = mock.Mock()
+        response.status_code = 200
+        response.content = "fecha,valor\n2024-05-01,1.50\n".encode("utf-8")
+        response.headers = {}
+        response.raise_for_status = mock.Mock()
+
+        with mock.patch.object(ipc_service.requests, "get", return_value=response) as mocked_get:
+            header, rows, status = ipc_service.leer_csv()
+
+        mocked_get.assert_called_once()
+        called_url = mocked_get.call_args.args[0]
+        self.assertEqual(called_url, custom_url)
+        self.assertEqual(header, ["fecha", "valor"])
+        self.assertEqual(rows, [["2024-05-01", "1.50"]])
+        self.assertEqual(status["source"], custom_url)
 
 
 class CacheFreshnessRuleTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- añadir un campo editable para la URL del CSV en la pantalla de configuración de administración
- reestructurar el servicio de configuración y las rutas para leer y persistir la URL dinámica
- actualizar la carga del IPC para consultar la URL configurada y cubrir el cambio con pruebas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb4a9698008332a6e26517c28400b8