### PR TITLE
Fix config CSV URL handling and add tests

### DIFF
--- a/services/config_service.py
+++ b/services/config_service.py
@@ -23,7 +23,19 @@ USER_CONFIG_KEYS = {"alquiler_base", "fecha_inicio_contrato", "periodo_actualiza
 def _sanitize_global_config(data: Any) -> Dict[str, Any]:
     if not isinstance(data, dict):
         return {}
+
     sanitized = {k: v for k, v in data.items() if k not in USER_CONFIG_KEYS}
+
+    csv_url_value = sanitized.get("csv_url")
+    if isinstance(csv_url_value, str):
+        stripped = csv_url_value.strip()
+        if stripped:
+            sanitized["csv_url"] = stripped
+        else:
+            sanitized.pop("csv_url", None)
+    elif "csv_url" in sanitized:
+        sanitized.pop("csv_url")
+
     return sanitized
 
 
@@ -40,7 +52,7 @@ def _write_config(data: Dict[str, Any]) -> None:
     else:
         to_store = data
     with open(path, "w", encoding="utf-8") as fh:
-        json.dump(data, fh, indent=2, sort_keys=True)
+        json.dump(to_store, fh, indent=2, sort_keys=True)
 
 
 def load_config() -> Dict[str, Any]:
@@ -65,3 +77,13 @@ def save_config(data: Dict[str, Any]) -> None:
 
     sanitized = _sanitize_global_config(data)
     _write_config(sanitized)
+
+
+def get_csv_url() -> str:
+    """Return the configured CSV URL, falling back to defaults."""
+
+    config = load_config()
+    csv_url = config.get("csv_url")
+    if isinstance(csv_url, str) and csv_url.strip():
+        return csv_url.strip()
+    return DEFAULT_CSV_URL

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -1,0 +1,54 @@
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from services import config_service
+
+
+class GetCsvUrlTests(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+
+        self.config_path = os.path.join(self.tmpdir.name, "config.json")
+        patcher = mock.patch.object(config_service, "CONFIG_FILE", self.config_path)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_returns_default_when_not_configured(self):
+        self.assertEqual(
+            config_service.get_csv_url(), config_service.DEFAULT_CSV_URL
+        )
+
+    def test_trims_value_and_persists_sanitized_copy(self):
+        original_value = "  https://example.com/ipc.csv  "
+        config_service.save_config({"csv_url": original_value})
+
+        self.assertEqual(
+            config_service.get_csv_url(), "https://example.com/ipc.csv"
+        )
+
+        with open(self.config_path, "r", encoding="utf-8") as fh:
+            stored = json.load(fh)
+        self.assertEqual(stored.get("csv_url"), "https://example.com/ipc.csv")
+
+    def test_invalid_value_falls_back_to_default(self):
+        config_service.save_config({"csv_url": 123})
+
+        self.assertEqual(
+            config_service.get_csv_url(), config_service.DEFAULT_CSV_URL
+        )
+        self.assertEqual(config_service.load_config(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- sanitize and persist configuration csv_url values while adding a get_csv_url helper
- ensure config writes use sanitized data to avoid stray whitespace
- add regression tests covering config URL loading and fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb5656ae708332ad613dda48ea85b6