### PR TITLE
Ajustar actualización mensual del IPC y mensajes de API

### DIFF
--- a/templates/config.html
+++ b/templates/config.html
@@ -33,9 +33,9 @@
         <input type="hidden" name="form_type" value="global">
         <input type="hidden" name="selected_user" value="{{ selected_user or '' }}">
         <div class="mb-3">
-          <label class="form-label" for="csv-url-input">URL del CSV del IPC</label>
+          <label class="form-label" for="csv-url-input">URL de la API del IPC</label>
           <input type="url" class="form-control" id="csv-url-input" name="csv_url" value="{{ csv_url_configured }}" placeholder="https://...">
-          <div class="form-text">Se aplica a todos los contratantes. Si queda vacío se usa la URL oficial del INDEC.</div>
+          <div class="form-text">Se aplica a todos los contratantes. Si queda vacío se usa la ruta oficial del INDEC.</div>
         </div>
         {% if global_config_extras %}
         {% for key, value in global_config_extras.items() %}
@@ -49,7 +49,7 @@
       </form>
       <div class="border rounded p-3 bg-light">
         <p class="mb-1"><strong>URL en uso:</strong> <code>{{ csv_url_current }}</code></p>
-        <p class="mb-1"><strong>Archivo descargado:</strong> {{ 'Sí' if csv_cache_info.has_cache else 'No' }}</p>
+        <p class="mb-1"><strong>Datos descargados:</strong> {{ 'Sí' if csv_cache_info.has_cache else 'No' }}</p>
         <p class="mb-0">
           <strong>Última descarga:</strong>
           {% if csv_cache_info.last_cached_at_text %}


### PR DESCRIPTION
## Resumen
- Actualicé la lógica del servicio de IPC para intentar descargar datos desde la API a partir del día 14 hasta contar con el mes previo y evitar nuevas consultas hasta el siguiente ciclo.
- Expuse en el estado de la caché si los datos continúan desactualizados tras una verificación y normalicé el cálculo del mes requerido.
- Ajusté los textos de la configuración para dejar en claro que se utiliza la API JSON del INDEC y que la URL puede configurarse.

## Pruebas
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb83b0bb408332a94a69a1bccf6bf3