### PR TITLE
Switch IPC source configuration to JSON API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-config/config.json
 config/users.json
 config/ipc.meta.json
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ docker run -d --name ipc-api -p 8000:8000 ipc-api
 
 ## Configuración
 Variables de entorno admitidas:
-- `CSV_URL`: URL de la API de IPC a usar (por defecto la oficial del INDEC). También se admite la variable legacy `CSV_DATOS`.
+- `IPC_API_URL`: URL de la API del IPC a usar (por defecto la oficial del INDEC). El valor configurado se guarda en `config/config.json` y puede editarse desde la pantalla de administración.
 - `ADMIN_USER` y `ADMIN_PASS`: credenciales para `/adm` (por defecto `admin`/`admin`).
 - `SECRET_KEY`: clave de sesión de Flask.
 

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,3 @@
+{
+  "api_url": "https://apis.datos.gob.ar/series/api/series?ids=145.3_INGNACUAL_DICI_M_38&format=json&start_date=2016-01&limit=1000"
+}

--- a/routes.py
+++ b/routes.py
@@ -18,11 +18,11 @@ from services.config_service import (
     save_config,
     ADMIN_USER,
     ADMIN_PASS,
-    get_csv_url,
+    get_api_url,
 )
 from services.ipc_service import (
     ipc_dict_with_status,
-    get_csv_cache_status,
+    get_cache_status,
 )
 from services.alquiler_service import generar_tabla_alquiler, meses_hasta_fin_anio
 from services.user_service import (
@@ -92,7 +92,7 @@ def ipc_ultimos():
         cache_info["last_checked_at"] = status["last_checked_at"].isoformat()
     return jsonify(
         {
-            "source": status.get("source") or get_csv_url(),
+            "source": status.get("source") or get_api_url(),
             "last_month": last_date,
             "count": len(out),
             "data": out,
@@ -189,13 +189,13 @@ def admin():
     """Pantalla de login y configuración"""
     if session.get("logged_in"):
         global_config = load_config()
-        csv_url_configured = global_config.get("csv_url", "")
-        csv_url_current = get_csv_url()
-        csv_cache_info = get_csv_cache_status()
+        api_url_configured = global_config.get("api_url", "")
+        api_url_current = get_api_url()
+        api_cache_info = get_cache_status()
         global_config_extras = {
             key: value
             for key, value in global_config.items()
-            if key not in {"csv_url"}
+            if key not in {"api_url"}
         }
 
         users = list_users()
@@ -217,13 +217,13 @@ def admin():
                         updated_config[key] = value
                     save_config(updated_config)
                     global_config = load_config()
-                    csv_url_configured = global_config.get("csv_url", "")
-                    csv_url_current = get_csv_url()
-                    csv_cache_info = get_csv_cache_status()
+                    api_url_configured = global_config.get("api_url", "")
+                    api_url_current = get_api_url()
+                    api_cache_info = get_cache_status()
                     global_config_extras = {
                         key: value
                         for key, value in global_config.items()
-                        if key not in {"csv_url"}
+                        if key not in {"api_url"}
                     }
                 else:
                     if not selected_user:
@@ -292,9 +292,9 @@ def admin():
             contratantes=users,
             selected_user=selected_user,
             tiene_config=tiene_config,
-            csv_url_configured=csv_url_configured,
-            csv_url_current=csv_url_current,
-            csv_cache_info=csv_cache_info,
+            api_url_configured=api_url_configured,
+            api_url_current=api_url_current,
+            api_cache_info=api_cache_info,
         )
 
     error = None

--- a/services/ipc_service.py
+++ b/services/ipc_service.py
@@ -148,7 +148,7 @@ def _parse_iso_datetime(value: str | None) -> datetime | None:
     return parsed
 
 
-def get_csv_cache_status() -> dict:
+def get_cache_status() -> dict:
     """Return information about the cached IPC data without triggering downloads."""
 
     has_cache = os.path.exists(CACHE_PATH)
@@ -204,14 +204,14 @@ def _parse_api_payload(payload: Any) -> tuple[list[str], list[list[str]]]:
     return header, rows
 
 
-def leer_csv():
-    """Leer y cachear los datos del IPC desde la API."""
-    csv_url = config_service.get_csv_url()
+def fetch_ipc_data():
+    """Fetch and cache IPC data from the configured API."""
+    api_url = config_service.get_api_url()
     meta = _read_meta()
     cache_exists = os.path.exists(CACHE_PATH)
 
     status = {
-        "source": csv_url,
+        "source": api_url,
         "used_cache": False,
         "updated": False,
         "stale": False,
@@ -243,7 +243,7 @@ def leer_csv():
 
     try:
         status["last_checked_at"] = datetime.now(timezone.utc)
-        response = requests.get(csv_url, timeout=20, headers=headers or None)
+        response = requests.get(api_url, timeout=20, headers=headers or None)
         if response.status_code == 304 and cache_exists:
             if cached_header is None or cached_rows is None:
                 cached_header, cached_rows = _load_cache_rows()
@@ -357,7 +357,7 @@ def _rows_to_monthly_variations(rows: list[list[str]]) -> dict[str, Decimal]:
 
 def ipc_dict_with_status():
     """Return IPC dictionary along with cache status metadata."""
-    _, filas, status = leer_csv()
+    _, filas, status = fetch_ipc_data()
     out = _rows_to_monthly_variations(filas)
     return out, status
 

--- a/templates/config.html
+++ b/templates/config.html
@@ -33,8 +33,8 @@
         <input type="hidden" name="form_type" value="global">
         <input type="hidden" name="selected_user" value="{{ selected_user or '' }}">
         <div class="mb-3">
-          <label class="form-label" for="csv-url-input">URL de la API del IPC</label>
-          <input type="url" class="form-control" id="csv-url-input" name="csv_url" value="{{ csv_url_configured }}" placeholder="https://...">
+          <label class="form-label" for="api-url-input">URL de la API del IPC</label>
+          <input type="url" class="form-control" id="api-url-input" name="api_url" value="{{ api_url_configured }}" placeholder="https://...">
           <div class="form-text">Se aplica a todos los contratantes. Si queda vacío se usa la ruta oficial del INDEC.</div>
         </div>
         {% if global_config_extras %}
@@ -48,14 +48,14 @@
         <button type="submit" class="btn btn-primary">Guardar ajustes del sistema</button>
       </form>
       <div class="border rounded p-3 bg-light">
-        <p class="mb-1"><strong>URL en uso:</strong> <code>{{ csv_url_current }}</code></p>
-        <p class="mb-1"><strong>Datos descargados:</strong> {{ 'Sí' if csv_cache_info.has_cache else 'No' }}</p>
+        <p class="mb-1"><strong>URL en uso:</strong> <code>{{ api_url_current }}</code></p>
+        <p class="mb-1"><strong>Datos descargados:</strong> {{ 'Sí' if api_cache_info.has_cache else 'No' }}</p>
         <p class="mb-0">
           <strong>Última descarga:</strong>
-          {% if csv_cache_info.last_cached_at_text %}
-            {{ csv_cache_info.last_cached_at_text }}
-          {% elif csv_cache_info.fetched_at_text %}
-            {{ csv_cache_info.fetched_at_text }}
+          {% if api_cache_info.last_cached_at_text %}
+            {{ api_cache_info.last_cached_at_text }}
+          {% elif api_cache_info.fetched_at_text %}
+            {{ api_cache_info.fetched_at_text }}
           {% else %}
             &mdash;
           {% endif %}

--- a/tests/test_config_service.py
+++ b/tests/test_config_service.py
@@ -14,7 +14,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from services import config_service
 
 
-class GetCsvUrlTests(unittest.TestCase):
+class GetApiUrlTests(unittest.TestCase):
     def setUp(self):
         self.tmpdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmpdir.cleanup)
@@ -26,28 +26,34 @@ class GetCsvUrlTests(unittest.TestCase):
 
     def test_returns_default_when_not_configured(self):
         self.assertEqual(
-            config_service.get_csv_url(), config_service.DEFAULT_CSV_URL
+            config_service.get_api_url(), config_service.DEFAULT_API_URL
         )
+        with open(self.config_path, "r", encoding="utf-8") as fh:
+            stored = json.load(fh)
+        self.assertEqual(stored.get("api_url"), config_service.DEFAULT_API_URL)
 
     def test_trims_value_and_persists_sanitized_copy(self):
-        original_value = "  https://example.com/ipc.csv  "
-        config_service.save_config({"csv_url": original_value})
+        original_value = "  https://example.com/ipc.json  "
+        config_service.save_config({"api_url": original_value})
 
         self.assertEqual(
-            config_service.get_csv_url(), "https://example.com/ipc.csv"
+            config_service.get_api_url(), "https://example.com/ipc.json"
         )
 
         with open(self.config_path, "r", encoding="utf-8") as fh:
             stored = json.load(fh)
-        self.assertEqual(stored.get("csv_url"), "https://example.com/ipc.csv")
+        self.assertEqual(stored.get("api_url"), "https://example.com/ipc.json")
 
     def test_invalid_value_falls_back_to_default(self):
-        config_service.save_config({"csv_url": 123})
+        config_service.save_config({"api_url": 123})
 
         self.assertEqual(
-            config_service.get_csv_url(), config_service.DEFAULT_CSV_URL
+            config_service.get_api_url(), config_service.DEFAULT_API_URL
         )
-        self.assertEqual(config_service.load_config(), {})
+        self.assertEqual(
+            config_service.load_config(),
+            {"api_url": config_service.DEFAULT_API_URL},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- persist the default IPC API URL in `config/config.json` and load/save it through new API-specific helpers
- rename IPC fetching helpers and UI labels to drop CSV terminology while still surfacing cache status in the admin panel
- refresh tests and documentation to target the JSON API workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb8844aa3c8332a9d73c716a557ff2