### PR TITLE
Permitir ingreso por nombre de contratante

### DIFF
--- a/routes.py
+++ b/routes.py
@@ -26,7 +26,7 @@ from services.ipc_service import (
 )
 from services.alquiler_service import generar_tabla_alquiler, meses_hasta_fin_anio
 from services.user_service import (
-    list_users,
+    find_user_by_name,
     add_user,
     delete_user,
     get_user_config,
@@ -107,10 +107,11 @@ def index():
     if not session.get("user"):
         error = None
         if request.method == "POST":
-            nombre = request.form.get("name", "").strip().lower()
-            if nombre and nombre in list_users():
+            nombre = request.form.get("name", "")
+            username = find_user_by_name(nombre)
+            if username:
                 session.clear()
-                session["user"] = nombre
+                session["user"] = username
                 session.permanent = False  # expira al cerrar el navegador
                 return redirect(url_for("app.index"))
             error = "Usuario no encontrado"

--- a/tests/test_user_service.py
+++ b/tests/test_user_service.py
@@ -1,0 +1,42 @@
+import pytest
+
+from services import user_service
+
+
+@pytest.fixture
+def users_file(tmp_path, monkeypatch):
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    file_path = config_dir / "users.json"
+    monkeypatch.setattr(user_service, "USERS_FILE", str(file_path))
+    return file_path
+
+
+def test_find_user_by_name_matches_configured_name_case_insensitive(users_file):
+    user_service.save_users(
+        {
+            "Juan Perez": {
+                "nombre": "Juan",
+                "apellido": "Pérez",
+            },
+            "josé": {
+                "nombre": "José",
+            },
+        }
+    )
+
+    assert user_service.find_user_by_name("juan") == "juan perez"
+    assert user_service.find_user_by_name("JUAN") == "juan perez"
+    assert user_service.find_user_by_name("Juan Pérez") == "juan perez"
+    assert user_service.find_user_by_name("Jose") == "josé"
+    assert user_service.find_user_by_name("josé") == "josé"
+
+
+def test_find_user_by_name_falls_back_to_identifier(users_file):
+    user_service.save_users({"Contrato-123": {}})
+
+    assert user_service.find_user_by_name("contrato-123") == "contrato-123"
+    assert user_service.find_user_by_name("CONTRATO-123") == "contrato-123"
+    assert user_service.find_user_by_name("desconocido") is None
+    assert user_service.find_user_by_name("   ") is None
+    assert user_service.find_user_by_name(None) is None


### PR DESCRIPTION
## Summary
- permitir iniciar sesión para contratantes buscando el nombre de forma insensible a mayúsculas y acentos
- añadir utilidades de normalización y búsqueda de nombres en el servicio de usuarios
- cubrir la búsqueda de contratantes con pruebas unitarias

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb9490ec2c8332ae3a628ac2ac1a82